### PR TITLE
ci(windows): pin 2026 image and pass LabVIEWYear

### DIFF
--- a/.github/workflows/labview-container-check-windows.yml
+++ b/.github/workflows/labview-container-check-windows.yml
@@ -17,12 +17,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Pull LabVIEW container image
-        run: docker pull nationalinstruments/labview:latest-windows
+        run: docker pull nationalinstruments/labview:2026q1-windows
 
       - name: Run LabVIEWCLI MassCompile on Arrays
         run: >
           docker run --rm
-          nationalinstruments/labview:latest-windows
+          nationalinstruments/labview:2026q1-windows
           LabVIEWCLI -OperationName MassCompile -DirectoryToCompile
           "C:\Program Files\National Instruments\LabVIEW 2026\examples\Arrays" -Headless
 
@@ -30,5 +30,5 @@ jobs:
         run: >
           docker run --rm
           -v "${{ github.workspace }}:C:\workspace"
-          nationalinstruments/labview:latest-windows
-          powershell -File "C:\workspace\examples\integration-into-cicd\runlabview.ps1" -WorkspaceRoot "C:\workspace"
+          nationalinstruments/labview:2026q1-windows
+          powershell -File "C:\workspace\examples\integration-into-cicd\runlabview.ps1" -WorkspaceRoot "C:\workspace" -LabVIEWYear 2026

--- a/.github/workflows/labview-container-check-windows.yml
+++ b/.github/workflows/labview-container-check-windows.yml
@@ -1,4 +1,4 @@
-name: Run LabVIEWCLI on Windows Container
+name: Regression Gates on Windows Container
 
 on:
   pull_request:
@@ -11,24 +11,26 @@ jobs:
   run-labview-cli-windows:
     # This job requires a runner with Docker configured for Windows containers.
     runs-on: windows-latest
+    env:
+      LABVIEW_IMAGE_WINDOWS: nationalinstruments/labview:2026q1-windows
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Pull LabVIEW container image
-        run: docker pull nationalinstruments/labview:2026q1-windows
+      - name: Pull LabVIEW container image (pinned)
+        run: docker pull ${{ env.LABVIEW_IMAGE_WINDOWS }}
 
-      - name: Run LabVIEWCLI MassCompile on Arrays
+      - name: "Gate 1 (Examples): MassCompile Arrays"
         run: >
           docker run --rm
-          nationalinstruments/labview:2026q1-windows
+          ${{ env.LABVIEW_IMAGE_WINDOWS }}
           LabVIEWCLI -OperationName MassCompile -DirectoryToCompile
           "C:\Program Files\National Instruments\LabVIEW 2026\examples\Arrays" -Headless
 
-      - name: Run CI integration script in container
+      - name: "Gate 2 (Examples): Run integration script"
         run: >
           docker run --rm
           -v "${{ github.workspace }}:C:\workspace"
-          nationalinstruments/labview:2026q1-windows
+          ${{ env.LABVIEW_IMAGE_WINDOWS }}
           powershell -File "C:\workspace\examples\integration-into-cicd\runlabview.ps1" -WorkspaceRoot "C:\workspace" -LabVIEWYear 2026

--- a/.github/workflows/labview-container-check.yml
+++ b/.github/workflows/labview-container-check.yml
@@ -1,4 +1,4 @@
-name: Run LabVIEWCLI on Linux Container
+name: Regression Gates on Linux Container
 
 on:
   pull_request:
@@ -10,23 +10,26 @@ on:
 jobs:
   run-labview-cli:
     runs-on: ubuntu-latest
+    env:
+      LABVIEW_IMAGE_LINUX: nationalinstruments/labview:2026q1-linux
+      LABVIEW_YEAR: "2026"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Pull LabVIEW container image
-        run: docker pull nationalinstruments/labview:latest-linux
+      - name: Pull LabVIEW container image (pinned)
+        run: docker pull ${{ env.LABVIEW_IMAGE_LINUX }}
 
-      - name: Run LabVIEWCLI MassCompile on Arrays
+      - name: "Gate 1 (Examples): MassCompile Arrays"
         run: |
           docker run --rm \
-            nationalinstruments/labview:latest-linux \
-            bash -c "LabVIEWCLI -OperationName MassCompile -DirectoryToCompile /usr/local/natinst/LabVIEW-2026-64/examples/Arrays -LabVIEWPath /usr/local/natinst/LabVIEW-2026-64/labview -Headless"
+            ${{ env.LABVIEW_IMAGE_LINUX }} \
+            bash -c "LabVIEWCLI -OperationName MassCompile -DirectoryToCompile /usr/local/natinst/LabVIEW-${LABVIEW_YEAR}-64/examples/Arrays -LabVIEWPath /usr/local/natinst/LabVIEW-${LABVIEW_YEAR}-64/labview -Headless"
 
-      - name: Run CI integration script in container
+      - name: "Gate 2 (Examples): Run integration script"
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
-            nationalinstruments/labview:latest-linux \
-            bash -c "cd /workspace/examples/integration-into-cicd && chmod +x runlabview.sh && ./runlabview.sh"
+            ${{ env.LABVIEW_IMAGE_LINUX }} \
+            bash -c "cd /workspace/examples/integration-into-cicd && chmod +x runlabview.sh && LV_YEAR=${LABVIEW_YEAR} ./runlabview.sh"
 


### PR DESCRIPTION
## Summary
Fixes deterministic Windows container check failure by removing year/tag ambiguity.

## Changes
- Pin Windows container image to `nationalinstruments/labview:2026q1-windows`
- Pass `-LabVIEWYear 2026` to `runlabview.ps1`

## Why
`runlabview.ps1` defaults to LabVIEW 2020 when `-LabVIEWYear` is omitted, which broke runs against `latest-windows` containing LabVIEW 2026.

Refs #3