### PR TITLE
Add image-contract certification workflow and summary schema

### DIFF
--- a/.github/workflows/labview-2020-stabilization-matrix.yml
+++ b/.github/workflows/labview-2020-stabilization-matrix.yml
@@ -126,9 +126,9 @@ jobs:
           @(
             "### LabVIEW 2020 Stabilization Result",
             "- Runner lane: hosted-2022",
-            "- Image: `${{ inputs.image_tag }}`",
-            "- Isolation: `${{ inputs.isolation_mode }}`",
-            "- Classification: `$classification`",
+            "- Image: ${{ inputs.image_tag }}",
+            "- Isolation: ${{ inputs.isolation_mode }}",
+            "- Classification: $classification",
             "- Summary path: " + ($(if ($null -ne $summaryPath) { $summaryPath } else { '<not-found>' }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
@@ -238,9 +238,9 @@ jobs:
           @(
             "### LabVIEW 2020 Stabilization Result",
             "- Runner lane: self-hosted-2019",
-            "- Image: `${{ inputs.image_tag }}`",
-            "- Isolation: `${{ inputs.isolation_mode }}`",
-            "- Classification: `$classification`",
+            "- Image: ${{ inputs.image_tag }}",
+            "- Isolation: ${{ inputs.isolation_mode }}",
+            "- Classification: $classification",
             "- Summary path: " + ($(if ($null -ne $summaryPath) { $summaryPath } else { '<not-found>' }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 

--- a/.github/workflows/labview-image-contract-certification.yml
+++ b/.github/workflows/labview-image-contract-certification.yml
@@ -1,0 +1,227 @@
+name: LabVIEW Image Contract Certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      contract_profile:
+        description: 'Contract profile from Tooling/image-contract-profiles.json'
+        required: true
+        default: '2026-x64-throughput'
+        type: choice
+        options:
+          - 2026-x64-throughput
+          - 2020-x64-stabilization
+      image_tag:
+        description: 'Image tag to certify'
+        required: true
+        default: 'nationalinstruments/labview:2026q1-windows'
+        type: string
+      runner_target:
+        description: 'Certification runner lane'
+        required: true
+        default: 'hosted-2022'
+        type: choice
+        options:
+          - hosted-2022
+          - self-hosted-server2019
+      isolation_mode:
+        description: 'Docker isolation mode'
+        required: true
+        default: 'process'
+        type: choice
+        options:
+          - process
+          - hyperv
+      max_cli_attempts:
+        description: 'Max CLI attempts per verifier run'
+        required: true
+        default: '2'
+        type: string
+      repeat_runs:
+        description: 'Override repeat runs (0 uses profile default)'
+        required: true
+        default: '2'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  certify-hosted:
+    if: ${{ inputs.runner_target == 'hosted-2022' }}
+    runs-on: windows-latest
+    timeout-minutes: 240
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run image contract certification
+        id: certify
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $logRoot = "TestResults/agent-logs/certification-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
+          New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
+
+          & .\examples\build-your-own-image\certify-image-contract.ps1 `
+            -ContractProfile '${{ inputs.contract_profile }}' `
+            -ImageTag '${{ inputs.image_tag }}' `
+            -RunnerTarget '${{ inputs.runner_target }}' `
+            -IsolationMode '${{ inputs.isolation_mode }}' `
+            -MaxCliAttempts ([int]'${{ inputs.max_cli_attempts }}') `
+            -RepeatRuns ([int]'${{ inputs.repeat_runs }}') `
+            -LogRoot $logRoot
+
+      - name: Classify certification result
+        id: classify
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $classification = '${{ steps.certify.outputs.cert_classification }}'
+          $summaryPath = '${{ steps.certify.outputs.cert_summary_path }}'
+
+          if ([string]::IsNullOrWhiteSpace($classification)) {
+            $classification = 'verifier_execution_error'
+          }
+
+          if (-not [string]::IsNullOrWhiteSpace($summaryPath) -and (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+            $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+            if (-not [string]::IsNullOrWhiteSpace([string]$summary.classification)) {
+              $classification = [string]$summary.classification
+            }
+          }
+
+          "classification=$classification" >> $env:GITHUB_OUTPUT
+          "summary_path=$summaryPath" >> $env:GITHUB_OUTPUT
+
+          @(
+            "### Image Contract Certification",
+            "- Contract profile: ${{ inputs.contract_profile }}",
+            "- Image tag: ${{ inputs.image_tag }}",
+            "- Runner lane: hosted-2022",
+            "- Classification: $classification",
+            "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
+          ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Upload certification artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-contract-certification-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            TestResults/agent-logs/certification-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+            builds/status/image-contract-cert-summary-*.json
+          if-no-files-found: warn
+
+      - name: Enforce pass classification
+        if: always()
+        shell: pwsh
+        run: |
+          if ('${{ steps.classify.outputs.classification }}' -ne 'pass') {
+            throw "Certification classification is ${{ steps.classify.outputs.classification }}"
+          }
+
+  certify-self-hosted-server2019:
+    if: ${{ inputs.runner_target == 'self-hosted-server2019' }}
+    runs-on:
+      - self-hosted
+      - windows
+      - server2019
+    timeout-minutes: 240
+    env:
+      LVIE_ENFORCE_DEDICATED_HOST_CONTRACT: '1'
+      LVIE_REQUIRED_LABVIEW_YEARS: '2020,2026'
+      LVIE_REQUIRED_CLI_MAJOR: '26'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Runner sanity (dedicated host contract)
+        uses: ./.github/actions/runner-bootstrap
+        with:
+          runner_sanity: 'true'
+          enforce_host_contract: 'true'
+          host_contract_path: Tooling/runner-host-contract.json
+          required_labview_years: ${{ env.LVIE_REQUIRED_LABVIEW_YEARS }}
+          required_cli_major: ${{ env.LVIE_REQUIRED_CLI_MAJOR }}
+
+      - name: Validate real Server 2019 base
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $os = Get-CimInstance -ClassName Win32_OperatingSystem
+          $caption = [string]$os.Caption
+          $build = [string]$os.BuildNumber
+          if ($caption -notmatch 'Server' -or $build -ne '17763') {
+            throw "Runner must be a real Server 2019 lane for 2020 eligibility. Caption='$caption' Build='$build'"
+          }
+
+      - name: Run image contract certification
+        id: certify
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $logRoot = "TestResults/agent-logs/certification-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
+          New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
+
+          & .\examples\build-your-own-image\certify-image-contract.ps1 `
+            -ContractProfile '${{ inputs.contract_profile }}' `
+            -ImageTag '${{ inputs.image_tag }}' `
+            -RunnerTarget '${{ inputs.runner_target }}' `
+            -IsolationMode '${{ inputs.isolation_mode }}' `
+            -MaxCliAttempts ([int]'${{ inputs.max_cli_attempts }}') `
+            -RepeatRuns ([int]'${{ inputs.repeat_runs }}') `
+            -LogRoot $logRoot
+
+      - name: Classify certification result
+        id: classify
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $classification = '${{ steps.certify.outputs.cert_classification }}'
+          $summaryPath = '${{ steps.certify.outputs.cert_summary_path }}'
+
+          if ([string]::IsNullOrWhiteSpace($classification)) {
+            $classification = 'verifier_execution_error'
+          }
+
+          if (-not [string]::IsNullOrWhiteSpace($summaryPath) -and (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+            $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+            if (-not [string]::IsNullOrWhiteSpace([string]$summary.classification)) {
+              $classification = [string]$summary.classification
+            }
+          }
+
+          "classification=$classification" >> $env:GITHUB_OUTPUT
+          "summary_path=$summaryPath" >> $env:GITHUB_OUTPUT
+
+          @(
+            "### Image Contract Certification",
+            "- Contract profile: ${{ inputs.contract_profile }}",
+            "- Image tag: ${{ inputs.image_tag }}",
+            "- Runner lane: self-hosted-server2019",
+            "- Classification: $classification",
+            "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
+          ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Upload certification artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-contract-certification-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            TestResults/agent-logs/certification-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+            builds/status/image-contract-cert-summary-*.json
+          if-no-files-found: warn
+
+      - name: Enforce pass classification
+        if: always()
+        shell: pwsh
+        run: |
+          if ('${{ steps.classify.outputs.classification }}' -ne 'pass') {
+            throw "Certification classification is ${{ steps.classify.outputs.classification }}"
+          }

--- a/Tooling/image-cert-summary.schema.json
+++ b/Tooling/image-cert-summary.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LabVIEW Image Contract Certification Summary",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_utc",
+    "contract_profile",
+    "image_tag",
+    "runner_fingerprint",
+    "verification_metrics",
+    "classification",
+    "promotion_eligible",
+    "reasons",
+    "source_log_paths"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "generated_utc": {
+      "type": "string"
+    },
+    "contract_profile": {
+      "type": "string"
+    },
+    "image_tag": {
+      "type": "string"
+    },
+    "runner_target": {
+      "type": "string"
+    },
+    "runner_fingerprint": {
+      "type": "object",
+      "required": [
+        "os_caption",
+        "os_version",
+        "os_build",
+        "docker_server_os",
+        "is_real_server2019"
+      ],
+      "properties": {
+        "os_caption": {
+          "type": "string"
+        },
+        "os_version": {
+          "type": "string"
+        },
+        "os_build": {
+          "type": "string"
+        },
+        "docker_server_os": {
+          "type": "string"
+        },
+        "is_real_server2019": {
+          "type": "boolean"
+        }
+      }
+    },
+    "verification_metrics": {
+      "type": "object",
+      "required": [
+        "repeat_runs_requested",
+        "runs_completed",
+        "pass_count",
+        "failure_count",
+        "all_runs_port_listening",
+        "any_minus_350000",
+        "run_results"
+      ],
+      "properties": {
+        "repeat_runs_requested": {
+          "type": "integer"
+        },
+        "runs_completed": {
+          "type": "integer"
+        },
+        "pass_count": {
+          "type": "integer"
+        },
+        "failure_count": {
+          "type": "integer"
+        },
+        "all_runs_port_listening": {
+          "type": "boolean"
+        },
+        "any_minus_350000": {
+          "type": "boolean"
+        },
+        "run_results": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "port_not_listening",
+        "cli_connect_fail",
+        "environment_incompatible",
+        "verifier_execution_error"
+      ]
+    },
+    "promotion_eligible": {
+      "type": "boolean"
+    },
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "source_log_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/Tooling/image-contract-profiles.json
+++ b/Tooling/image-contract-profiles.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0",
+  "profiles": {
+    "2020-x64-stabilization": {
+      "lv_year": "2020",
+      "lv_cli_port": "3363",
+      "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2020\\examples\\Arrays",
+      "requires_real_server2019": true,
+      "required_repeat_runs": 2
+    },
+    "2026-x64-throughput": {
+      "lv_year": "2026",
+      "lv_cli_port": "3363",
+      "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2026\\examples\\Arrays",
+      "requires_real_server2019": false,
+      "required_repeat_runs": 2
+    }
+  }
+}

--- a/examples/build-your-own-image/certify-image-contract.ps1
+++ b/examples/build-your-own-image/certify-image-contract.ps1
@@ -1,0 +1,273 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ContractProfile,
+    [Parameter(Mandatory = $true)][string]$ImageTag,
+    [string]$RunnerTarget = 'hosted-2022',
+    [ValidateSet('process', 'hyperv')][string]$IsolationMode = 'process',
+    [ValidateRange(1, 10)][int]$MaxCliAttempts = 2,
+    [string]$LogRoot = 'TestResults/agent-logs',
+    [int]$RepeatRuns = 0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Get-RepoRoot {
+    return (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+function Get-RunnerFingerprint {
+    $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction SilentlyContinue
+    $caption = if ($null -ne $os) { [string]$os.Caption } else { '' }
+    $version = if ($null -ne $os) { [string]$os.Version } else { '' }
+    $build = if ($null -ne $os) { [string]$os.BuildNumber } else { '' }
+    $isRealServer2019 = ($caption -match 'Server') -and ($build -eq '17763')
+
+    $dockerServerOs = 'unknown'
+    try {
+        $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+        if ([string]::IsNullOrWhiteSpace($dockerServerOs)) {
+            $dockerServerOs = 'unknown'
+        }
+    }
+    catch {
+        $dockerServerOs = 'unavailable'
+    }
+
+    return [ordered]@{
+        os_caption = $caption
+        os_version = $version
+        os_build = $build
+        docker_server_os = $dockerServerOs
+        is_real_server2019 = $isRealServer2019
+    }
+}
+
+function Get-RunSummaryPath {
+    param([Parameter(Mandatory = $true)][string]$RunRoot)
+
+    $summary = Get-ChildItem -LiteralPath $RunRoot -Recurse -File -Filter 'summary.json' -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $summary) {
+        return $null
+    }
+
+    return $summary.FullName
+}
+
+$repoRoot = Get-RepoRoot
+$profilePath = Join-Path $repoRoot 'Tooling\image-contract-profiles.json'
+$schemaPath = Join-Path $repoRoot 'Tooling\image-cert-summary.schema.json'
+$verifierScriptPath = Join-Path $PSScriptRoot 'verify-lv-cli-masscompile-from-image.ps1'
+$statusRoot = Join-Path $repoRoot 'builds\status'
+
+Ensure-Directory -Path $statusRoot
+if (-not (Test-Path -LiteralPath $profilePath -PathType Leaf)) {
+    throw "Image contract profile file not found: $profilePath"
+}
+if (-not (Test-Path -LiteralPath $schemaPath -PathType Leaf)) {
+    throw "Image certification schema file not found: $schemaPath"
+}
+if (-not (Test-Path -LiteralPath $verifierScriptPath -PathType Leaf)) {
+    throw "Verifier script not found: $verifierScriptPath"
+}
+
+$profiles = Get-Content -LiteralPath $profilePath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+if (-not $profiles.PSObject.Properties.Name.Contains('profiles')) {
+    throw "Invalid profile file: missing 'profiles' object at $profilePath"
+}
+if (-not $profiles.profiles.PSObject.Properties.Name.Contains($ContractProfile)) {
+    $availableProfiles = @($profiles.profiles.PSObject.Properties.Name) -join ', '
+    throw "Unknown ContractProfile '$ContractProfile'. Available profiles: $availableProfiles"
+}
+
+$profile = $profiles.profiles.$ContractProfile
+$lvYear = [string]$profile.lv_year
+$lvCliPort = [string]$profile.lv_cli_port
+$directoryToCompile = [string]$profile.directory_to_compile
+$requiresRealServer2019 = [bool]$profile.requires_real_server2019
+$profileRepeatRuns = [int]$profile.required_repeat_runs
+$effectiveRepeatRuns = if ($RepeatRuns -gt 0) { [int]$RepeatRuns } else { [int]$profileRepeatRuns }
+if ($effectiveRepeatRuns -lt 1) {
+    $effectiveRepeatRuns = 1
+}
+
+$resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
+Ensure-Directory -Path $resolvedLogRoot
+
+$runStamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmss-fff')
+$certRunRoot = Join-Path $resolvedLogRoot ("certification-{0}" -f $runStamp)
+Ensure-Directory -Path $certRunRoot
+
+$fingerprint = Get-RunnerFingerprint
+$reasons = New-Object System.Collections.Generic.List[string]
+$sourceLogPaths = New-Object System.Collections.Generic.List[string]
+$runResults = New-Object System.Collections.Generic.List[object]
+$passCount = 0
+$failureCount = 0
+
+if ($requiresRealServer2019 -and -not $fingerprint.is_real_server2019) {
+    $reasons.Add('Profile requires real Server 2019 lane; current runner fingerprint does not satisfy this requirement.') | Out-Null
+}
+
+for ($index = 1; $index -le $effectiveRepeatRuns; $index++) {
+    $runLogRoot = Join-Path $certRunRoot ("run-{0:00}" -f $index)
+    Ensure-Directory -Path $runLogRoot
+    $sourceLogPaths.Add($runLogRoot) | Out-Null
+
+    $runError = ''
+    $runSummaryPath = $null
+    $runSummary = $null
+    $runPass = $false
+    $runFinalExit = $null
+    $runContains350000 = $null
+    $runPortListening = $null
+
+    try {
+        & $verifierScriptPath `
+            -ImageTag $ImageTag `
+            -LvYear $lvYear `
+            -LvCliPort $lvCliPort `
+            -DirectoryToCompile $directoryToCompile `
+            -IsolationMode $IsolationMode `
+            -MaxCliAttempts $MaxCliAttempts `
+            -LogRoot $runLogRoot
+    }
+    catch {
+        $runError = $_.Exception.Message
+    }
+
+    $runSummaryPath = Get-RunSummaryPath -RunRoot $runLogRoot
+    if (-not [string]::IsNullOrWhiteSpace($runSummaryPath) -and (Test-Path -LiteralPath $runSummaryPath -PathType Leaf)) {
+        $sourceLogPaths.Add($runSummaryPath) | Out-Null
+        try {
+            $runSummary = Get-Content -LiteralPath $runSummaryPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+            $runFinalExit = if ($null -ne $runSummary.final_exit_code) { [int]$runSummary.final_exit_code } else { $null }
+            $runContains350000 = [bool]$runSummary.contains_minus_350000
+            $runPortListening = [bool]$runSummary.port_listening_before_cli
+            $runPass = [bool]$runSummary.run_succeeded -and ($runFinalExit -eq 0) -and (-not $runContains350000) -and $runPortListening
+        }
+        catch {
+            if ([string]::IsNullOrWhiteSpace($runError)) {
+                $runError = "Unable to parse verifier summary at ${runSummaryPath}: $($_.Exception.Message)"
+            }
+        }
+    }
+    elseif ([string]::IsNullOrWhiteSpace($runError)) {
+        $runError = 'Verifier summary.json was not found.'
+    }
+
+    if ($runPass) {
+        $passCount += 1
+    }
+    else {
+        $failureCount += 1
+    }
+
+    $runResults.Add([pscustomobject]@{
+        run_index = $index
+        pass = $runPass
+        summary_path = $runSummaryPath
+        final_exit_code = $runFinalExit
+        contains_minus_350000 = $runContains350000
+        port_listening_before_cli = $runPortListening
+        error = $runError
+        logs_path = $runLogRoot
+    }) | Out-Null
+}
+
+$anyMinus350000 = $false
+$allPortListening = $true
+foreach ($result in $runResults) {
+    if ($result.contains_minus_350000 -eq $true) {
+        $anyMinus350000 = $true
+    }
+    if ($result.port_listening_before_cli -ne $true) {
+        $allPortListening = $false
+    }
+}
+
+$classification = 'verifier_execution_error'
+if ($requiresRealServer2019 -and -not $fingerprint.is_real_server2019) {
+    $classification = 'environment_incompatible'
+}
+elseif ($failureCount -eq 0 -and $passCount -eq $effectiveRepeatRuns) {
+    $classification = 'pass'
+}
+elseif (-not $allPortListening) {
+    $classification = 'port_not_listening'
+}
+elseif ($anyMinus350000 -or ($runResults | Where-Object { $_.final_exit_code -ne $null -and $_.final_exit_code -ne 0 }).Count -gt 0) {
+    $classification = 'cli_connect_fail'
+}
+
+if ($classification -eq 'pass') {
+    $reasons.Add("All $effectiveRepeatRuns run(s) passed with listening port and no -350000.") | Out-Null
+}
+elseif ($classification -eq 'port_not_listening') {
+    $reasons.Add('At least one run reported port_listening_before_cli=false.') | Out-Null
+}
+elseif ($classification -eq 'cli_connect_fail') {
+    $reasons.Add('At least one run had -350000 or a non-zero final_exit_code.') | Out-Null
+}
+elseif ($classification -eq 'verifier_execution_error') {
+    $reasons.Add('Verifier execution failed before producing a passing summary set.') | Out-Null
+}
+
+$promotionEligible = ($classification -eq 'pass') -and ($passCount -eq $effectiveRepeatRuns)
+if ($requiresRealServer2019 -and -not $fingerprint.is_real_server2019) {
+    $promotionEligible = $false
+}
+
+$safeProfile = ($ContractProfile -replace '[^A-Za-z0-9_.-]', '-')
+$summaryTimestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmss-fff')
+$certSummaryPath = Join-Path $statusRoot ("image-contract-cert-summary-{0}-{1}.json" -f $safeProfile, $summaryTimestamp)
+
+$summary = [ordered]@{
+    schema_version = '1.0'
+    generated_utc = (Get-Date).ToUniversalTime().ToString('o')
+    contract_profile = $ContractProfile
+    image_tag = $ImageTag
+    runner_target = $RunnerTarget
+    runner_fingerprint = $fingerprint
+    verification_metrics = [ordered]@{
+        repeat_runs_requested = $effectiveRepeatRuns
+        runs_completed = $runResults.Count
+        pass_count = $passCount
+        failure_count = $failureCount
+        all_runs_port_listening = $allPortListening
+        any_minus_350000 = $anyMinus350000
+        run_results = $runResults
+    }
+    classification = $classification
+    promotion_eligible = $promotionEligible
+    reasons = @($reasons)
+    source_log_paths = @($sourceLogPaths | Select-Object -Unique)
+    schema_path = $schemaPath
+    profile_path = $profilePath
+}
+
+$summary | ConvertTo-Json -Depth 12 | Set-Content -Path $certSummaryPath -Encoding utf8
+Write-Host "cert_summary_path=$certSummaryPath"
+Write-Host "cert_classification=$classification"
+Write-Host "promotion_eligible=$promotionEligible"
+
+if ($env:GITHUB_OUTPUT) {
+    Add-Content -Path $env:GITHUB_OUTPUT -Value ("cert_summary_path={0}" -f $certSummaryPath)
+    Add-Content -Path $env:GITHUB_OUTPUT -Value ("cert_classification={0}" -f $classification)
+    Add-Content -Path $env:GITHUB_OUTPUT -Value ("promotion_eligible={0}" -f $promotionEligible.ToString().ToLowerInvariant())
+}
+
+if ($classification -ne 'pass') {
+    throw "Image contract certification failed with classification '$classification'. See $certSummaryPath"
+}

--- a/examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1
+++ b/examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1
@@ -1,0 +1,424 @@
+[CmdletBinding()]
+param(
+    [string]$ImageTag = 'labview-custom-windows:2020q1-windows-p3363-candidate',
+    [string]$LvYear = '2020',
+    [string]$LvCliPort = '3363',
+    [string]$DirectoryToCompile = '',
+    [int]$WarmupSeconds = 60,
+    [int]$ListenPollTimeoutSeconds = 180,
+    [int]$MaxCliAttempts = 2,
+    [ValidateSet('process', 'hyperv')]
+    [string]$IsolationMode = 'process',
+    [switch]$KeepContainer,
+    [string]$LogRoot = 'TestResults/agent-logs'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-DockerCommand {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [int[]]$AllowedExitCodes = @(0),
+        [string]$LogPath = ''
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & docker @Arguments 2>&1
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    foreach ($line in @($output)) {
+        if ($null -eq $line) {
+            continue
+        }
+        $text = [string]$line
+        Write-Host $text
+        if (-not [string]::IsNullOrWhiteSpace($LogPath)) {
+            Add-Content -Path $LogPath -Value $text
+        }
+    }
+
+    if ($AllowedExitCodes -notcontains $exitCode) {
+        throw "$Description failed with exit code $exitCode."
+    }
+
+    return $exitCode
+}
+
+function Invoke-ContainerPowerShell {
+    param(
+        [Parameter(Mandatory = $true)][string]$ContainerName,
+        [Parameter(Mandatory = $true)][string]$StepName,
+        [Parameter(Mandatory = $true)][string]$CommandText,
+        [Parameter(Mandatory = $true)][string]$RunLogRoot,
+        [int[]]$AllowedExitCodes = @()
+    )
+
+    $stepLogPath = Join-Path $RunLogRoot ($StepName + '.log')
+    New-Item -Path $stepLogPath -ItemType File -Force | Out-Null
+    $args = @(
+        'exec',
+        $ContainerName,
+        'powershell',
+        '-NoProfile',
+        '-Command', $CommandText
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & docker @args 2>&1
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    foreach ($line in @($output)) {
+        if ($null -eq $line) {
+            continue
+        }
+        $text = [string]$line
+        Add-Content -Path $stepLogPath -Value $text
+        Write-Host $text
+    }
+
+    if ($AllowedExitCodes.Count -gt 0 -and ($AllowedExitCodes -notcontains $exitCode)) {
+        throw "Container step '$StepName' failed with exit code $exitCode. See $stepLogPath"
+    }
+
+    return [pscustomobject]@{
+        StepName = $StepName
+        ExitCode = $exitCode
+        LogPath  = $stepLogPath
+    }
+}
+
+function Remove-ContainerIfPresent {
+    param([string]$ContainerName)
+
+    if ([string]::IsNullOrWhiteSpace($ContainerName)) {
+        return
+    }
+
+    & docker container inspect $ContainerName > $null 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        & docker rm -f $ContainerName > $null 2>&1
+    }
+}
+
+if ($WarmupSeconds -lt 0) {
+    throw 'WarmupSeconds must be >= 0.'
+}
+if ($ListenPollTimeoutSeconds -lt 1) {
+    throw 'ListenPollTimeoutSeconds must be >= 1.'
+}
+if ($MaxCliAttempts -lt 1) {
+    throw 'MaxCliAttempts must be >= 1.'
+}
+$LvCliPort = $LvCliPort.Trim()
+if ($LvCliPort -ne '3363') {
+    throw "LvCliPort must be '3363'. Received: '$LvCliPort'"
+}
+$LvYear = $LvYear.Trim()
+if ([string]::IsNullOrWhiteSpace($LvYear)) {
+    throw 'LvYear must not be empty.'
+}
+if ([string]::IsNullOrWhiteSpace($DirectoryToCompile)) {
+    $DirectoryToCompile = "C:\Program Files\National Instruments\LabVIEW $LvYear\examples\Arrays"
+}
+$IsolationMode = $IsolationMode.Trim().ToLowerInvariant()
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
+New-Item -Path $resolvedLogRoot -ItemType Directory -Force | Out-Null
+
+$runTimestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$runLogRoot = Join-Path $resolvedLogRoot ("p3363-single-run-{0}" -f $runTimestamp)
+New-Item -Path $runLogRoot -ItemType Directory -Force | Out-Null
+
+$preflightPath = Join-Path $runLogRoot 'preflight.txt'
+
+try {
+    $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to query Docker server mode. Ensure Docker Desktop is running.'
+    }
+    if ($dockerServerOs -ne 'windows') {
+        throw "Docker server is not in Windows mode. Current server OS: $dockerServerOs"
+    }
+
+    & docker image inspect $ImageTag > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Image not found locally: $ImageTag"
+    }
+}
+catch {
+    throw $_
+}
+
+@(
+    "timestamp=$((Get-Date).ToString('o'))",
+    "image_tag=$ImageTag",
+    "lv_year=$LvYear",
+    "lv_cli_port=$LvCliPort",
+    "directory_to_compile=$DirectoryToCompile",
+    "warmup_seconds=$WarmupSeconds",
+    "listen_poll_timeout_seconds=$ListenPollTimeoutSeconds",
+    "max_cli_attempts=$MaxCliAttempts",
+    "isolation_mode=$IsolationMode"
+) | Set-Content -Path $preflightPath -Encoding ascii
+
+$containerName = "p3363-verify-{0}" -f ([Guid]::NewGuid().ToString('N').Substring(0, 8))
+$containerCreated = $false
+$containerKept = $false
+$stepHistory = @()
+$portListeningBeforeCli = $false
+$firstAttemptExit = -1
+$secondAttemptExit = $null
+$containsMinus350000 = $false
+$finalExitCode = 1
+$failureMessage = ''
+
+$iniCheckTemplate = @'
+$ErrorActionPreference = 'Stop'
+$expectedPort = '__PORT__'
+$lvIni = 'C:\Program Files\National Instruments\LabVIEW __YEAR__\LabVIEW.ini'
+$cliIni = 'C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini'
+if (-not (Test-Path -LiteralPath $lvIni -PathType Leaf)) { Write-Host ('MISSING=' + $lvIni); exit 21 }
+if (-not (Test-Path -LiteralPath $cliIni -PathType Leaf)) { Write-Host ('MISSING=' + $cliIni); exit 22 }
+$lvTokens = Get-Content -LiteralPath $lvIni | Where-Object { $_ -match '^server\.tcp\.(enabled|port)=' }
+$cliTokens = Get-Content -LiteralPath $cliIni | Where-Object { $_ -match '^DefaultPortNumber\s*=' }
+$lvTokens | ForEach-Object { Write-Host $_ }
+$cliTokens | ForEach-Object { Write-Host $_ }
+$lvMatch = $lvTokens -contains ('server.tcp.port=' + $expectedPort)
+$cliMatch = (($cliTokens | Where-Object { $_ -match ('^DefaultPortNumber\s*=\s*' + [regex]::Escape($expectedPort) + '$') }).Count -gt 0)
+if ($lvMatch -and $cliMatch) { Write-Host 'INI_PORT_MATCH=true'; exit 0 }
+Write-Host 'INI_PORT_MATCH=false'
+exit 23
+'@
+
+$readinessTemplate = @'
+$ErrorActionPreference = 'Continue'
+$lvExe = 'C:\Program Files\National Instruments\LabVIEW __YEAR__\LabVIEW.exe'
+$port = '__PORT__'
+$altPort = if ($port -eq '3363') { '3366' } else { '3363' }
+$warmup = __WARMUP__
+$timeout = __TIMEOUT__
+if (-not (Test-Path -LiteralPath $lvExe -PathType Leaf)) { Write-Host ('MISSING=' + $lvExe); exit 31 }
+Start-Process -FilePath $lvExe -ArgumentList '--headless' -WindowStyle Hidden | Out-Null
+if ($warmup -gt 0) {
+  Write-Host ('WARMUP_SECONDS=' + $warmup)
+  Start-Sleep -Seconds $warmup
+}
+$deadline = (Get-Date).AddSeconds($timeout)
+$pattern = ':' + [regex]::Escape($port) + '\s+.*LISTENING'
+$altPattern = ':' + [regex]::Escape($altPort) + '\s+.*LISTENING'
+$isListening = $false
+$tick = 0
+while ((Get-Date) -lt $deadline) {
+  $tick += 1
+  $now = (Get-Date).ToString('o')
+  $proc = @(Get-Process -Name 'LabVIEW*' -ErrorAction SilentlyContinue)
+  $procCount = $proc.Count
+  $procNames = if ($procCount -gt 0) { (($proc | Select-Object -ExpandProperty ProcessName -Unique) -join ',') } else { '<none>' }
+  $net = netstat -ano
+  $matches = @($net | Select-String -Pattern $pattern)
+  $altMatches = @($net | Select-String -Pattern $altPattern)
+  Write-Host ('TICK=' + $tick + ';TIME=' + $now + ';LABVIEW_PROC_COUNT=' + $procCount + ';LABVIEW_PROCS=' + $procNames + ';LISTEN_' + $port + '=' + $matches.Count + ';LISTEN_' + $altPort + '=' + $altMatches.Count)
+  if ($matches.Count -gt 0) { $isListening = $true; break }
+  Start-Sleep -Seconds 2
+}
+if ($isListening) {
+  Write-Host 'PORT_LISTENING=true'
+  netstat -ano | Select-String -Pattern $pattern | ForEach-Object { $_.ToString() }
+  netstat -ano | Select-String -Pattern $altPattern | ForEach-Object { $_.ToString() }
+} else {
+  Write-Host 'PORT_LISTENING=false'
+}
+exit 0
+'@
+
+$massCompileTemplate = @'
+$ErrorActionPreference = 'Continue'
+$lvExe = 'C:\Program Files\National Instruments\LabVIEW __YEAR__\LabVIEW.exe'
+$target = '__DIR__'
+$port = '__PORT__'
+if (-not (Test-Path -LiteralPath $lvExe -PathType Leaf)) { Write-Host ('MISSING=' + $lvExe); exit 41 }
+if (-not (Test-Path -LiteralPath $target -PathType Container)) { Write-Host ('MISSING=' + $target); exit 42 }
+& LabVIEWCLI -LogToConsole TRUE -LabVIEWPath $lvExe -OperationName MassCompile -DirectoryToCompile $target -PortNumber $port -Headless
+$code = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+Write-Host ('ATTEMPT_EXIT_CODE=' + $code)
+exit $code
+'@
+
+$diagnosticsTemplate = @'
+$ErrorActionPreference = 'Continue'
+$port = '__PORT__'
+$lvYear = '__YEAR__'
+$diagRoot = 'C:\ni\temp\verify-diag'
+New-Item -Path $diagRoot -ItemType Directory -Force | Out-Null
+$lvIni = 'C:\Program Files\National Instruments\LabVIEW ' + $lvYear + '\LabVIEW.ini'
+$cliIni = 'C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini'
+if (Test-Path -LiteralPath $lvIni -PathType Leaf) { Copy-Item -LiteralPath $lvIni -Destination (Join-Path $diagRoot 'LabVIEW.ini') -Force }
+if (Test-Path -LiteralPath $cliIni -PathType Leaf) { Copy-Item -LiteralPath $cliIni -Destination (Join-Path $diagRoot 'LabVIEWCLI.ini') -Force }
+$net = netstat -ano
+$net | Out-File -Encoding utf8 (Join-Path $diagRoot 'netstat.txt')
+$altPort = if ($port -eq '3363') { '3366' } else { '3363' }
+$listen = @($net | Select-String -Pattern (':' + [regex]::Escape($port) + '\s+.*LISTENING'))
+$listenAlt = @($net | Select-String -Pattern (':' + [regex]::Escape($altPort) + '\s+.*LISTENING'))
+@(
+  'port=' + $port,
+  'alternate_port=' + $altPort,
+  ('listening_count_' + $port + '=' + $listen.Count),
+  ('listening_count_' + $altPort + '=' + $listenAlt.Count)
+) | Set-Content -Path (Join-Path $diagRoot 'port-status.txt') -Encoding ascii
+if ($listen.Count -gt 0) { $listen | ForEach-Object { $_.ToString() } | Set-Content -Path (Join-Path $diagRoot 'port-listening-lines.txt') -Encoding ascii }
+if ($listenAlt.Count -gt 0) { $listenAlt | ForEach-Object { $_.ToString() } | Set-Content -Path (Join-Path $diagRoot 'alternate-port-listening-lines.txt') -Encoding ascii }
+Get-Process | Sort-Object ProcessName | Select-Object ProcessName,Id,Path | Out-File -Encoding utf8 (Join-Path $diagRoot 'processes.txt')
+$tempRoot = Join-Path $diagRoot 'lvtemporary'
+New-Item -Path $tempRoot -ItemType Directory -Force | Out-Null
+Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Filter 'lvtemporary_*.log' -File -ErrorAction SilentlyContinue | ForEach-Object {
+  Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $tempRoot $_.Name) -Force
+}
+$userRoot = Join-Path $diagRoot 'labview-user-logs'
+New-Item -Path $userRoot -ItemType Directory -Force | Out-Null
+$roots = @('C:\Users\ContainerAdministrator\AppData\Local\Temp', 'C:\Users\ContainerAdministrator\AppData\Local', 'C:\Users\ContainerAdministrator\AppData\Roaming')
+$patterns = @('LabVIEWCLI*_cur.txt', 'LabVIEW*_cur.txt', 'LabVIEWCLI*.log', 'LabVIEW*.log')
+foreach ($root in $roots) {
+  if (-not (Test-Path -LiteralPath $root -PathType Container)) { continue }
+  foreach ($pat in $patterns) {
+    Get-ChildItem -Path $root -Recurse -File -Filter $pat -ErrorAction SilentlyContinue | Select-Object -First 200 | ForEach-Object {
+      $name = ($_.DirectoryName -replace '[:\\ ]', '_') + '_' + $_.Name
+      $dest = Join-Path $userRoot $name
+      if (-not (Test-Path -LiteralPath $dest -PathType Leaf)) { Copy-Item -LiteralPath $_.FullName -Destination $dest -Force }
+    }
+  }
+}
+exit 0
+'@
+
+$iniCheckCmd = $iniCheckTemplate.Replace('__PORT__', $LvCliPort).Replace('__YEAR__', $LvYear)
+$readinessCmd = $readinessTemplate.Replace('__PORT__', $LvCliPort).Replace('__YEAR__', $LvYear).Replace('__WARMUP__', [string]$WarmupSeconds).Replace('__TIMEOUT__', [string]$ListenPollTimeoutSeconds)
+$massCompileCmd = $massCompileTemplate.Replace('__PORT__', $LvCliPort).Replace('__YEAR__', $LvYear).Replace('__DIR__', ($DirectoryToCompile -replace "'", "''"))
+$diagnosticsCmd = $diagnosticsTemplate.Replace('__PORT__', $LvCliPort).Replace('__YEAR__', $LvYear)
+
+try {
+    $dockerRunLogPath = Join-Path $runLogRoot 'docker-run.log'
+    New-Item -Path $dockerRunLogPath -ItemType File -Force | Out-Null
+    $dockerRunArgs = @('run')
+    if ($IsolationMode -eq 'hyperv') {
+        $dockerRunArgs += '--isolation=hyperv'
+    }
+    $dockerRunArgs += @('--name', $containerName, '--detach', $ImageTag, 'powershell', '-NoProfile', '-Command', 'Start-Sleep -Seconds 21600')
+    Invoke-DockerCommand -Arguments $dockerRunArgs -Description 'start verifier container' -LogPath $dockerRunLogPath | Out-Null
+    $containerCreated = $true
+
+    $iniResult = Invoke-ContainerPowerShell -ContainerName $containerName -StepName 'ini-check' -CommandText $iniCheckCmd -RunLogRoot $runLogRoot -AllowedExitCodes @(0)
+    $stepHistory += $iniResult
+
+    $readinessResult = Invoke-ContainerPowerShell -ContainerName $containerName -StepName 'readiness' -CommandText $readinessCmd -RunLogRoot $runLogRoot -AllowedExitCodes @(0)
+    $stepHistory += $readinessResult
+    $portListeningBeforeCli = ((Get-Content -LiteralPath $readinessResult.LogPath -Raw) -match 'PORT_LISTENING=true')
+
+    $attempt1 = Invoke-ContainerPowerShell -ContainerName $containerName -StepName 'masscompile-attempt1' -CommandText $massCompileCmd -RunLogRoot $runLogRoot
+    $stepHistory += $attempt1
+    $firstAttemptExit = $attempt1.ExitCode
+    $attempt1Log = Get-Content -LiteralPath $attempt1.LogPath -Raw
+    $attempt1Has350000 = $attempt1Log -match '-350000'
+    $containsMinus350000 = $attempt1Has350000
+
+    if ($firstAttemptExit -ne 0 -and $attempt1Has350000 -and $MaxCliAttempts -ge 2) {
+        Start-Sleep -Seconds 10
+        $attempt2 = Invoke-ContainerPowerShell -ContainerName $containerName -StepName 'masscompile-attempt2' -CommandText $massCompileCmd -RunLogRoot $runLogRoot
+        $stepHistory += $attempt2
+        $secondAttemptExit = $attempt2.ExitCode
+        $attempt2Log = Get-Content -LiteralPath $attempt2.LogPath -Raw
+        if ($attempt2Log -match '-350000') {
+            $containsMinus350000 = $true
+        }
+    }
+
+    if ($null -ne $secondAttemptExit) {
+        $finalExitCode = [int]$secondAttemptExit
+    }
+    else {
+        $finalExitCode = [int]$firstAttemptExit
+    }
+}
+catch {
+    $failureMessage = $_.Exception.Message
+}
+finally {
+    if ($containerCreated) {
+        try {
+            $diagResult = Invoke-ContainerPowerShell -ContainerName $containerName -StepName 'diagnostics' -CommandText $diagnosticsCmd -RunLogRoot $runLogRoot
+            $stepHistory += $diagResult
+        }
+        catch {
+            Write-Warning ('Diagnostics capture command failed: ' + $_.Exception.Message)
+        }
+
+        & docker stop $containerName > $null 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to stop container '$containerName'."
+        }
+
+        $copyLogPath = Join-Path $runLogRoot 'docker-cp.log'
+        New-Item -Path $copyLogPath -ItemType File -Force | Out-Null
+        try {
+            Invoke-DockerCommand -Arguments @('cp', ($containerName + ':C:\ni\temp\verify-diag'), $runLogRoot) -Description 'copy diagnostics' -LogPath $copyLogPath | Out-Null
+        }
+        catch {
+            Write-Warning ('Diagnostics copy failed: ' + $_.Exception.Message)
+        }
+
+        if ($KeepContainer.IsPresent) {
+            $containerKept = $true
+        }
+        else {
+            Remove-ContainerIfPresent -ContainerName $containerName
+        }
+    }
+
+    $summary = [ordered]@{
+        timestamp_utc               = (Get-Date).ToUniversalTime().ToString('o')
+        image_tag                   = $ImageTag
+        container_name              = $containerName
+        container_kept              = $containerKept
+        lv_year                     = $LvYear
+        lv_cli_port                 = $LvCliPort
+        directory_to_compile        = $DirectoryToCompile
+        warmup_seconds              = $WarmupSeconds
+        listen_poll_timeout_seconds = $ListenPollTimeoutSeconds
+        max_cli_attempts            = $MaxCliAttempts
+        isolation_mode              = $IsolationMode
+        port_listening_before_cli   = $portListeningBeforeCli
+        first_attempt_exit          = $firstAttemptExit
+        second_attempt_exit         = $secondAttemptExit
+        contains_minus_350000       = $containsMinus350000
+        final_exit_code             = $finalExitCode
+        run_succeeded               = ($finalExitCode -eq 0 -and -not $containsMinus350000)
+        failure_message             = $failureMessage
+        logs_path                   = $runLogRoot
+        step_history                = $stepHistory
+    }
+
+    $summaryPath = Join-Path $runLogRoot 'summary.json'
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -Path $summaryPath -Encoding ascii
+    Write-Host "summary_path=$summaryPath"
+}
+
+if ($finalExitCode -ne 0 -or $containsMinus350000) {
+    if ([string]::IsNullOrWhiteSpace($failureMessage)) {
+        $failureMessage = "MassCompile verification failed. See logs at $runLogRoot"
+    }
+    throw $failureMessage
+}
+
+Write-Host 'MassCompile verification succeeded.'


### PR DESCRIPTION
Publishes the minimal image-contract certification surface needed for workflow_dispatch:

- .github/workflows/labview-image-contract-certification.yml
- examples/build-your-own-image/certify-image-contract.ps1
- Tooling/image-contract-profiles.json
- Tooling/image-cert-summary.schema.json
- docs/windows-custom-images.md
- examples/build-your-own-image/Resources/Windows Resources/Install-LV2020x64.ps1
- examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1

Reason: GitHub workflow_dispatch by filename requires workflow presence on default branch (main).

Refs #6
Follow-up to #1 (closed)
