### PR TITLE
Certification: hosted image preflight pull + preflight failure classification

### DIFF
--- a/.github/workflows/labview-image-contract-certification.yml
+++ b/.github/workflows/labview-image-contract-certification.yml
@@ -55,6 +55,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Ensure hosted image availability (preflight)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $imageTag = '${{ inputs.image_tag }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($imageTag)) {
+            throw 'workflow input image_tag is empty.'
+          }
+
+          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to query Docker server mode on hosted runner.'
+          }
+          if ($dockerServerOs -ne 'windows') {
+            throw "Hosted runner Docker mode must be windows. Current: $dockerServerOs"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Image already available locally: $imageTag"
+            exit 0
+          }
+
+          Write-Host "Image not present locally, pulling: $imageTag"
+          & docker pull $imageTag
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to pull required image: $imageTag"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pulled image could not be inspected: $imageTag"
+          }
+
       - name: Run image contract certification
         id: certify
         continue-on-error: true

--- a/examples/build-your-own-image/certify-image-contract.ps1
+++ b/examples/build-your-own-image/certify-image-contract.ps1
@@ -222,7 +222,7 @@ elseif ($failureCount -eq 0 -and $passCount -eq $effectiveRepeatRuns) {
 elseif ($hasMissingImageError -or $hasPreflightOrExecutionError) {
     $classification = 'verifier_execution_error'
 }
-elseif ($anyMinus350000 -or ($runResults | Where-Object { $_.final_exit_code -ne $null -and $_.final_exit_code -ne 0 }).Count -gt 0) {
+elseif ($anyMinus350000 -or @($runResults | Where-Object { $_.final_exit_code -ne $null -and $_.final_exit_code -ne 0 }).Count -gt 0) {
     $classification = 'cli_connect_fail'
 }
 elseif (-not $allPortListening) {

--- a/examples/build-your-own-image/certify-image-contract.ps1
+++ b/examples/build-your-own-image/certify-image-contract.ps1
@@ -188,12 +188,27 @@ for ($index = 1; $index -le $effectiveRepeatRuns; $index++) {
 
 $anyMinus350000 = $false
 $allPortListening = $true
+$hasPreflightOrExecutionError = $false
+$hasMissingImageError = $false
+$firstRunError = ''
 foreach ($result in $runResults) {
     if ($result.contains_minus_350000 -eq $true) {
         $anyMinus350000 = $true
     }
     if ($result.port_listening_before_cli -ne $true) {
         $allPortListening = $false
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$result.error)) {
+        $hasPreflightOrExecutionError = $true
+        if ([string]::IsNullOrWhiteSpace($firstRunError)) {
+            $firstRunError = [string]$result.error
+        }
+        if ([string]$result.error -match '(?i)image not found locally|no such image|manifest unknown|pull access denied') {
+            $hasMissingImageError = $true
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$result.summary_path)) {
+        $hasPreflightOrExecutionError = $true
     }
 }
 
@@ -204,11 +219,14 @@ if ($requiresRealServer2019 -and -not $fingerprint.is_real_server2019) {
 elseif ($failureCount -eq 0 -and $passCount -eq $effectiveRepeatRuns) {
     $classification = 'pass'
 }
-elseif (-not $allPortListening) {
-    $classification = 'port_not_listening'
+elseif ($hasMissingImageError -or $hasPreflightOrExecutionError) {
+    $classification = 'verifier_execution_error'
 }
 elseif ($anyMinus350000 -or ($runResults | Where-Object { $_.final_exit_code -ne $null -and $_.final_exit_code -ne 0 }).Count -gt 0) {
     $classification = 'cli_connect_fail'
+}
+elseif (-not $allPortListening) {
+    $classification = 'port_not_listening'
 }
 
 if ($classification -eq 'pass') {
@@ -221,7 +239,15 @@ elseif ($classification -eq 'cli_connect_fail') {
     $reasons.Add('At least one run had -350000 or a non-zero final_exit_code.') | Out-Null
 }
 elseif ($classification -eq 'verifier_execution_error') {
-    $reasons.Add('Verifier execution failed before producing a passing summary set.') | Out-Null
+    if ($hasMissingImageError) {
+        $reasons.Add("Image acquisition/preflight failed (missing image). First error: $firstRunError") | Out-Null
+    }
+    else {
+        $reasons.Add('Verifier execution failed before producing a passing summary set.') | Out-Null
+        if (-not [string]::IsNullOrWhiteSpace($firstRunError)) {
+            $reasons.Add("First run error: $firstRunError") | Out-Null
+        }
+    }
 }
 
 $promotionEligible = ($classification -eq 'pass') -and ($passCount -eq $effectiveRepeatRuns)
@@ -247,6 +273,8 @@ $summary = [ordered]@{
         failure_count = $failureCount
         all_runs_port_listening = $allPortListening
         any_minus_350000 = $anyMinus350000
+        has_preflight_or_execution_error = $hasPreflightOrExecutionError
+        has_missing_image_error = $hasMissingImageError
         run_results = $runResults
     }
     classification = $classification


### PR DESCRIPTION
Refs #6\n\n## What this changes\n- Adds a hosted preflight step in .github/workflows/labview-image-contract-certification.yml to ensure the requested image is available before certification:\n  - validate Docker Windows mode\n  - docker image inspect\n  - docker pull when missing\n  - re-inspect after pull\n- Tightens classification logic in xamples/build-your-own-image/certify-image-contract.ps1:\n  - missing-image/preflight/execution errors classify as erifier_execution_error\n  - avoids misclassifying missing image as port_not_listening\n  - adds metrics flags: has_preflight_or_execution_error, has_missing_image_error\n\n## Why\nPrevious hosted run 22263181794 failed because 
ationalinstruments/labview:2026q1-windows was not present locally on runner, but summary classified as port_not_listening. This PR makes acquisition deterministic and classification accurate.