### PR TITLE
Add AGENTS.md and confirm shivaCode-2-patch-4 parity

### DIFF
--- a/.github/workflows/labview-image-contract-certification.yml
+++ b/.github/workflows/labview-image-contract-certification.yml
@@ -55,6 +55,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Ensure hosted image availability (preflight)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $imageTag = '${{ inputs.image_tag }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($imageTag)) {
+            throw 'workflow input image_tag is empty.'
+          }
+
+          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to query Docker server mode on hosted runner.'
+          }
+          if ($dockerServerOs -ne 'windows') {
+            throw "Hosted runner Docker mode must be windows. Current: $dockerServerOs"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Image already available locally: $imageTag"
+            exit 0
+          }
+
+          Write-Host "Image not present locally, pulling: $imageTag"
+          & docker pull $imageTag
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to pull required image: $imageTag"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pulled image could not be inspected: $imageTag"
+          }
+
       - name: Run image contract certification
         id: certify
         continue-on-error: true
@@ -105,6 +139,21 @@ jobs:
             "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
+      - name: Assert certification evidence contract
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $minimumRepeatRuns = [int]'${{ inputs.repeat_runs }}'
+          if ($minimumRepeatRuns -le 0) {
+            $minimumRepeatRuns = 1
+          }
+          & .\Tooling\Assert-ImageCertificationEvidence.ps1 `
+            -SummaryPath '${{ steps.classify.outputs.summary_path }}' `
+            -ExpectedContractProfile '${{ inputs.contract_profile }}' `
+            -ExpectedImageTag '${{ inputs.image_tag }}' `
+            -MinRepeatRuns $minimumRepeatRuns
+
       - name: Upload certification artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -137,6 +186,40 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Ensure self-hosted image availability (preflight)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $imageTag = '${{ inputs.image_tag }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($imageTag)) {
+            throw 'workflow input image_tag is empty.'
+          }
+
+          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to query Docker server mode on self-hosted runner.'
+          }
+          if ($dockerServerOs -ne 'windows') {
+            throw "Self-hosted runner Docker mode must be windows. Current: $dockerServerOs"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Image already available locally: $imageTag"
+            exit 0
+          }
+
+          Write-Host "Image not present locally, pulling: $imageTag"
+          & docker pull $imageTag
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to pull required image: $imageTag"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pulled image could not be inspected: $imageTag"
+          }
 
       - name: Runner sanity (dedicated host contract)
         uses: ./.github/actions/runner-bootstrap
@@ -207,6 +290,21 @@ jobs:
             "- Classification: $classification",
             "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Assert certification evidence contract
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $minimumRepeatRuns = [int]'${{ inputs.repeat_runs }}'
+          if ($minimumRepeatRuns -le 0) {
+            $minimumRepeatRuns = 1
+          }
+          & .\Tooling\Assert-ImageCertificationEvidence.ps1 `
+            -SummaryPath '${{ steps.classify.outputs.summary_path }}' `
+            -ExpectedContractProfile '${{ inputs.contract_profile }}' `
+            -ExpectedImageTag '${{ inputs.image_tag }}' `
+            -MinRepeatRuns $minimumRepeatRuns
 
       - name: Upload certification artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Working Contract
+
+## Scope
+These instructions apply to this repository (`labview-for-containers`) and should be used by coding agents working in this repo.
+
+## Safety Rules
+- Do not run destructive git commands (`reset --hard`, `checkout --`) unless explicitly requested.
+- If the current worktree is dirty, use an isolated git worktree for integration work.
+- Keep evidence logs under `TestResults/agent-logs` and do not delete prior diagnostic bundles unless requested.
+
+## Shell and PowerShell Policy
+- Use `powershell -NoProfile -NonInteractive` for Windows script execution.
+- Do not use `-ExecutionPolicy Bypass`.
+- Prefer repository scripts over ad-hoc inline command blocks when a script already exists.
+
+## Windows Container Preflight
+Before running Windows image or certification flows:
+- Confirm Docker server mode is `windows`.
+- Confirm the requested image tag exists locally, or acquire it explicitly.
+- Fail fast on preflight failures and classify them distinctly from runtime LabVIEWCLI failures.
+
+## Certification and Classification
+- Use `examples/build-your-own-image/certify-image-contract.ps1` for image-contract certification.
+- Always persist `builds/status/image-contract-cert-summary-*.json` and associated run logs.
+- Treat missing-image/preflight failures as `verifier_execution_error`.
+
+## 2020 Promotion Guardrail
+- Keep canonical `labview-custom-windows:2020q1-windows` frozen until certification gates pass.
+- Promotion requires two consecutive fresh passes with:
+  - `final_exit_code = 0`
+  - `contains_minus_350000 = false`
+  - `port_listening_before_cli = true`
+
+## Branching and Traceability
+- Prefer feature branches named by issue scope.
+- Reference issues in commit/PR descriptions (for example `Refs #<issue>`).
+- Keep changes minimal and scoped to a single concern per branch whenever possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,111 @@
-# Agent Working Contract
+# Agent Operating Contract
 
 ## Scope
-These instructions apply to this repository (`labview-for-containers`) and should be used by coding agents working in this repo.
+These instructions apply to this repository (`labview-for-containers`) and define how coding agents should execute changes, run validation, and publish evidence.
 
-## Safety Rules
+## Intent
+- Keep delivery moving on deterministic green paths.
+- Stabilize risky lanes without contaminating canonical image tags.
+- Prefer auditable, machine-readable evidence over ad-hoc conclusions.
+
+## Safety and Worktree Discipline
 - Do not run destructive git commands (`reset --hard`, `checkout --`) unless explicitly requested.
-- If the current worktree is dirty, use an isolated git worktree for integration work.
-- Keep evidence logs under `TestResults/agent-logs` and do not delete prior diagnostic bundles unless requested.
+- If the active worktree is dirty, create an isolated worktree for merge/integration tasks.
+- Do not delete prior diagnostics under `TestResults/agent-logs` unless explicitly requested.
+- Keep each branch focused on one concern (for example, certification workflow logic vs docs).
 
 ## Shell and PowerShell Policy
 - Use `powershell -NoProfile -NonInteractive` for Windows script execution.
 - Do not use `-ExecutionPolicy Bypass`.
-- Prefer repository scripts over ad-hoc inline command blocks when a script already exists.
+- Prefer repo scripts over large inline command blocks when a script exists.
 
-## Windows Container Preflight
-Before running Windows image or certification flows:
-- Confirm Docker server mode is `windows`.
-- Confirm the requested image tag exists locally, or acquire it explicitly.
-- Fail fast on preflight failures and classify them distinctly from runtime LabVIEWCLI failures.
+## Deterministic Execution Order
+Run validations in this order and stop at the first failing gate:
+1. Gate 0: Environment preflight
+2. Gate 1: Integration example smoke
+3. Gate 2: Image verifier smoke
+4. Gate 3: Image contract certification
+5. Gate 4: Phase-3/PPL throughput work
 
-## Certification and Classification
-- Use `examples/build-your-own-image/certify-image-contract.ps1` for image-contract certification.
-- Always persist `builds/status/image-contract-cert-summary-*.json` and associated run logs.
-- Treat missing-image/preflight failures as `verifier_execution_error`.
+## Gate Definitions
 
-## 2020 Promotion Guardrail
-- Keep canonical `labview-custom-windows:2020q1-windows` frozen until certification gates pass.
-- Promotion requires two consecutive fresh passes with:
-  - `final_exit_code = 0`
-  - `contains_minus_350000 = false`
-  - `port_listening_before_cli = true`
+### Gate 0: Environment Preflight
+- Verify Docker server mode is `windows` before any Windows image flow.
+- Verify target image availability (inspect; pull/acquire if remote).
+- Verify required local paths/scripts exist before run dispatch.
+- Preflight failures are execution/preparation failures, not CLI runtime failures.
 
-## Branching and Traceability
-- Prefer feature branches named by issue scope.
-- Reference issues in commit/PR descriptions (for example `Refs #<issue>`).
-- Keep changes minimal and scoped to a single concern per branch whenever possible.
+### Gate 1: Integration Example Smoke
+- Use `examples/integration-into-cicd/runlabview.ps1`.
+- Always pass explicit `-LabVIEWYear` or explicit `-LabVIEWPath`.
+- Treat default-year assumptions as unsafe when image year differs.
+
+### Gate 2: Image Verifier Smoke
+- Use `examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1`.
+- Use explicit `-LvYear` and `-LvCliPort`.
+- Capture and preserve diagnostics (summary, netstat, process list, INI snapshots, temporary logs).
+
+### Gate 3: Image Contract Certification
+- Use `examples/build-your-own-image/certify-image-contract.ps1`.
+- Publish and preserve `builds/status/image-contract-cert-summary-*.json`.
+- Certification classification is authoritative for pass/fail decisions.
+
+### Gate 4: Phase-3/PPL Throughput
+- Start only after Gate 3 (or explicit exception approved in issue/PR).
+- Throughput track must not silently alter 2020 promotion policy.
+
+## Split-Track Strategy
+
+### Track A: 2026 Throughput
+- Objective: keep artifact throughput green.
+- Expected lane: hosted 2022.
+- Acceptable for delivery while 2020 stabilization is ongoing.
+
+### Track B: 2020 Stabilization
+- Objective: remove non-determinism and satisfy promotion gate.
+- Prefer self-hosted real Server 2019 lane for promotion eligibility.
+- Keep canonical `labview-custom-windows:2020q1-windows` frozen until gate passes.
+
+## Promotion Guardrail (2020 Canonical Tag)
+Do not retag canonical 2020 image unless two consecutive fresh runs satisfy all:
+- `final_exit_code = 0`
+- `contains_minus_350000 = false`
+- `port_listening_before_cli = true`
+- certification summary indicates promotion eligibility.
+
+## Failure Taxonomy and First Response
+- `environment_incompatible`
+  - Fix runner/OS lane first; do not tune image yet.
+- `verifier_execution_error`
+  - Fix preflight/acquisition/script execution path first.
+- `port_not_listening`
+  - Focus on LabVIEW readiness/launch timing and listener diagnostics.
+- `cli_connect_fail`
+  - Focus on CLI-to-LabVIEW connectivity and retry semantics.
+
+## Headless Runtime Rules
+- Headless and interactive IDE sessions are mutually exclusive.
+- If a UI/IDE session was launched, close it before headless CLI automation.
+- Prefer passing `-Headless` explicitly for clarity/reliability.
+- For triage, always capture console output plus LabVIEW/LabVIEWCLI logs.
+
+## Evidence Contract
+For every non-trivial run, persist:
+- run command/context
+- output summary JSON
+- key diagnostics (`netstat`, process list, INI snapshots, temp logs)
+- link to workflow run URL when run in CI
+- classification and next action in one short conclusion
+
+## GitHub Workflow and Issue Discipline
+- Reference issue IDs in commit messages/PR descriptions (`Refs #<issue>`).
+- Document classification outcomes in issue comments with artifact paths.
+- If an issue is already closed, open a new issue for new scope rather than overloading the closed one.
+
+## Source-of-Truth Files
+- `docs/windows-custom-images.md`
+- `docs/faqs.md`
+- `.github/workflows/labview-image-contract-certification.yml`
+- `examples/build-your-own-image/certify-image-contract.ps1`
+- `examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1`
+- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`

--- a/Tooling/Assert-ImageCertificationEvidence.ps1
+++ b/Tooling/Assert-ImageCertificationEvidence.ps1
@@ -1,0 +1,170 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$SummaryPath,
+    [string]$ExpectedContractProfile = '',
+    [string]$ExpectedImageTag = '',
+    [int]$MinRepeatRuns = 1,
+    [switch]$RequireLocalSourceLogPaths
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-HasProperty {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if (-not $Object.PSObject.Properties.Name.Contains($Name)) {
+        throw "Missing required property '$Name'."
+    }
+}
+
+function Assert-StringNotBlank {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "Property '$Name' must be a non-empty string."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
+    throw 'SummaryPath is empty. Certification did not produce a summary file path.'
+}
+
+if (-not (Test-Path -LiteralPath $SummaryPath -PathType Leaf)) {
+    throw "Summary file not found: $SummaryPath"
+}
+
+$summary = Get-Content -LiteralPath $SummaryPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+
+$requiredTop = @(
+    'schema_version',
+    'generated_utc',
+    'contract_profile',
+    'image_tag',
+    'runner_fingerprint',
+    'verification_metrics',
+    'classification',
+    'promotion_eligible',
+    'reasons',
+    'source_log_paths'
+)
+foreach ($name in $requiredTop) {
+    Assert-HasProperty -Object $summary -Name $name
+}
+
+Assert-StringNotBlank -Value ([string]$summary.schema_version) -Name 'schema_version'
+Assert-StringNotBlank -Value ([string]$summary.generated_utc) -Name 'generated_utc'
+Assert-StringNotBlank -Value ([string]$summary.contract_profile) -Name 'contract_profile'
+Assert-StringNotBlank -Value ([string]$summary.image_tag) -Name 'image_tag'
+Assert-StringNotBlank -Value ([string]$summary.classification) -Name 'classification'
+
+if (-not [string]::IsNullOrWhiteSpace($ExpectedContractProfile) -and [string]$summary.contract_profile -ne $ExpectedContractProfile) {
+    throw "contract_profile mismatch. expected='$ExpectedContractProfile' actual='$($summary.contract_profile)'"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedImageTag) -and [string]$summary.image_tag -ne $ExpectedImageTag) {
+    throw "image_tag mismatch. expected='$ExpectedImageTag' actual='$($summary.image_tag)'"
+}
+
+$allowedClassifications = @(
+    'pass',
+    'port_not_listening',
+    'cli_connect_fail',
+    'environment_incompatible',
+    'verifier_execution_error'
+)
+if ($allowedClassifications -notcontains [string]$summary.classification) {
+    throw "classification '$($summary.classification)' is not in allowed set: $($allowedClassifications -join ', ')"
+}
+
+$metrics = $summary.verification_metrics
+$requiredMetrics = @(
+    'repeat_runs_requested',
+    'runs_completed',
+    'pass_count',
+    'failure_count',
+    'all_runs_port_listening',
+    'any_minus_350000',
+    'has_preflight_or_execution_error',
+    'has_missing_image_error',
+    'run_results'
+)
+foreach ($name in $requiredMetrics) {
+    Assert-HasProperty -Object $metrics -Name $name
+}
+
+$effectiveMinRepeatRuns = if ($MinRepeatRuns -gt 0) { $MinRepeatRuns } else { 1 }
+$repeatRunsRequested = [int]$metrics.repeat_runs_requested
+$runsCompleted = [int]$metrics.runs_completed
+$passCount = [int]$metrics.pass_count
+$failureCount = [int]$metrics.failure_count
+$runResults = @($metrics.run_results)
+
+if ($repeatRunsRequested -lt $effectiveMinRepeatRuns) {
+    throw "repeat_runs_requested ($repeatRunsRequested) is below required minimum ($effectiveMinRepeatRuns)."
+}
+if ($runsCompleted -lt 1) {
+    throw "runs_completed must be >= 1. Actual: $runsCompleted"
+}
+if ($runsCompleted -ne $runResults.Count) {
+    throw "runs_completed ($runsCompleted) must match run_results count ($($runResults.Count))."
+}
+if (($passCount + $failureCount) -ne $runsCompleted) {
+    throw "pass_count + failure_count must equal runs_completed. pass_count=$passCount failure_count=$failureCount runs_completed=$runsCompleted"
+}
+
+if ($summary.reasons -isnot [System.Collections.IEnumerable] -or @($summary.reasons).Count -lt 1) {
+    throw 'reasons must contain at least one entry.'
+}
+if ($summary.source_log_paths -isnot [System.Collections.IEnumerable] -or @($summary.source_log_paths).Count -lt 1) {
+    throw 'source_log_paths must contain at least one entry.'
+}
+
+$missingSourcePaths = New-Object System.Collections.Generic.List[string]
+if ($RequireLocalSourceLogPaths) {
+    foreach ($path in @($summary.source_log_paths)) {
+        if ([string]::IsNullOrWhiteSpace([string]$path)) {
+            continue
+        }
+        if (-not (Test-Path -LiteralPath ([string]$path))) {
+            $missingSourcePaths.Add([string]$path) | Out-Null
+        }
+    }
+}
+
+$requiredRunResultProperties = @(
+    'run_index',
+    'pass',
+    'summary_path',
+    'final_exit_code',
+    'contains_minus_350000',
+    'port_listening_before_cli',
+    'error',
+    'logs_path'
+)
+foreach ($runResult in $runResults) {
+    foreach ($propertyName in $requiredRunResultProperties) {
+        Assert-HasProperty -Object $runResult -Name $propertyName
+    }
+}
+
+if ([string]$summary.classification -eq 'pass') {
+    if ($passCount -ne $runsCompleted) {
+        throw "classification=pass requires pass_count == runs_completed. pass_count=$passCount runs_completed=$runsCompleted"
+    }
+    if (-not [bool]$summary.promotion_eligible) {
+        throw 'classification=pass requires promotion_eligible=true.'
+    }
+}
+
+if ($missingSourcePaths.Count -gt 0) {
+    throw "Missing local source_log_paths detected: $($missingSourcePaths -join '; ')"
+}
+
+Write-Host "Certification evidence contract verified: $SummaryPath"
+Write-Host "classification=$($summary.classification); runs_completed=$runsCompleted; pass_count=$passCount; failure_count=$failureCount"

--- a/Tooling/image-cert-summary.schema.json
+++ b/Tooling/image-cert-summary.schema.json
@@ -66,6 +66,8 @@
         "failure_count",
         "all_runs_port_listening",
         "any_minus_350000",
+        "has_preflight_or_execution_error",
+        "has_missing_image_error",
         "run_results"
       ],
       "properties": {
@@ -85,6 +87,12 @@
           "type": "boolean"
         },
         "any_minus_350000": {
+          "type": "boolean"
+        },
+        "has_preflight_or_execution_error": {
+          "type": "boolean"
+        },
+        "has_missing_image_error": {
           "type": "boolean"
         },
         "run_results": {


### PR DESCRIPTION
## Summary
- compared `origin/main` with `upstream/shivaCode-2-patch-4`
- attempted cherry-pick of upstream-only commits (`a0b159b`, `3b60406`)
- both commits were empty after conflict resolution, confirming no net changes to import into current `main`
- add repository-level `AGENTS.md` with working contract for future coding agents

## Notes
- done in isolated worktree to avoid touching existing dirty working tree

## Validation
- git comparison: `origin/main...upstream/shivaCode-2-patch-4`
- cherry-pick attempts completed as no-op