### PR TITLE
Issue #6: 2026-first certification stabilization + canonical docs harmonization

### DIFF
--- a/.github/workflows/labview-image-contract-certification.yml
+++ b/.github/workflows/labview-image-contract-certification.yml
@@ -55,6 +55,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Ensure hosted image availability (preflight)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $imageTag = '${{ inputs.image_tag }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($imageTag)) {
+            throw 'workflow input image_tag is empty.'
+          }
+
+          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to query Docker server mode on hosted runner.'
+          }
+          if ($dockerServerOs -ne 'windows') {
+            throw "Hosted runner Docker mode must be windows. Current: $dockerServerOs"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Image already available locally: $imageTag"
+            exit 0
+          }
+
+          Write-Host "Image not present locally, pulling: $imageTag"
+          & docker pull $imageTag
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to pull required image: $imageTag"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pulled image could not be inspected: $imageTag"
+          }
+
       - name: Run image contract certification
         id: certify
         continue-on-error: true
@@ -105,6 +139,21 @@ jobs:
             "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
+      - name: Assert certification evidence contract
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $minimumRepeatRuns = [int]'${{ inputs.repeat_runs }}'
+          if ($minimumRepeatRuns -le 0) {
+            $minimumRepeatRuns = 1
+          }
+          & .\Tooling\Assert-ImageCertificationEvidence.ps1 `
+            -SummaryPath '${{ steps.classify.outputs.summary_path }}' `
+            -ExpectedContractProfile '${{ inputs.contract_profile }}' `
+            -ExpectedImageTag '${{ inputs.image_tag }}' `
+            -MinRepeatRuns $minimumRepeatRuns
+
       - name: Upload certification artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -137,6 +186,40 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Ensure self-hosted image availability (preflight)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $imageTag = '${{ inputs.image_tag }}'.Trim()
+          if ([string]::IsNullOrWhiteSpace($imageTag)) {
+            throw 'workflow input image_tag is empty.'
+          }
+
+          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to query Docker server mode on self-hosted runner.'
+          }
+          if ($dockerServerOs -ne 'windows') {
+            throw "Self-hosted runner Docker mode must be windows. Current: $dockerServerOs"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Image already available locally: $imageTag"
+            exit 0
+          }
+
+          Write-Host "Image not present locally, pulling: $imageTag"
+          & docker pull $imageTag
+          if ($LASTEXITCODE -ne 0) {
+            throw "Unable to pull required image: $imageTag"
+          }
+
+          & docker image inspect $imageTag > $null 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pulled image could not be inspected: $imageTag"
+          }
 
       - name: Runner sanity (dedicated host contract)
         uses: ./.github/actions/runner-bootstrap
@@ -207,6 +290,21 @@ jobs:
             "- Classification: $classification",
             "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Assert certification evidence contract
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $minimumRepeatRuns = [int]'${{ inputs.repeat_runs }}'
+          if ($minimumRepeatRuns -le 0) {
+            $minimumRepeatRuns = 1
+          }
+          & .\Tooling\Assert-ImageCertificationEvidence.ps1 `
+            -SummaryPath '${{ steps.classify.outputs.summary_path }}' `
+            -ExpectedContractProfile '${{ inputs.contract_profile }}' `
+            -ExpectedImageTag '${{ inputs.image_tag }}' `
+            -MinRepeatRuns $minimumRepeatRuns
 
       - name: Upload certification artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,29 @@ For every non-trivial run, persist:
 - Document classification outcomes in issue comments with artifact paths.
 - If an issue is already closed, open a new issue for new scope rather than overloading the closed one.
 
+## Docs Harmonization Contract
+- Keep `docs/windows-custom-images.md` canonical-first and aligned to NI structure.
+- Place fork-specific procedures/policy in `docs/windows-custom-images-operations.md`.
+- Keep `docs/build-your-own-image.md` as entry/navigation and include links to both canonical and fork operations guides.
+- Do not re-introduce fork-only troubleshooting/promotion policy into `docs/windows-custom-images.md`.
+- Do not remove cross-links between canonical and fork operations docs.
+
+## Docs Validation Checklist
+- Heading parity: `docs/windows-custom-images.md` must include NI canonical sections in order:
+  - `Prerequisites`
+  - `Important Considerations`
+  - `Dockerfile Overview`
+  - `How to Build the Image`
+  - `Final Notes`
+  - `What's next`
+- Link integrity: internal links in modified docs resolve and target existing docs.
+- Command sanity: Windows PowerShell command blocks in modified docs remain runnable as written.
+- Scope check: fork-only stabilization details are present in `docs/windows-custom-images-operations.md`, not mixed into canonical sections.
+
 ## Source-of-Truth Files
+- `docs/build-your-own-image.md`
 - `docs/windows-custom-images.md`
+- `docs/windows-custom-images-operations.md`
 - `docs/faqs.md`
 - `.github/workflows/labview-image-contract-certification.yml`
 - `examples/build-your-own-image/certify-image-contract.ps1`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Working Contract
+
+## Scope
+These instructions apply to this repository (`labview-for-containers`) and should be used by coding agents working in this repo.
+
+## Safety Rules
+- Do not run destructive git commands (`reset --hard`, `checkout --`) unless explicitly requested.
+- If the current worktree is dirty, use an isolated git worktree for integration work.
+- Keep evidence logs under `TestResults/agent-logs` and do not delete prior diagnostic bundles unless requested.
+
+## Shell and PowerShell Policy
+- Use `powershell -NoProfile -NonInteractive` for Windows script execution.
+- Do not use `-ExecutionPolicy Bypass`.
+- Prefer repository scripts over ad-hoc inline command blocks when a script already exists.
+
+## Windows Container Preflight
+Before running Windows image or certification flows:
+- Confirm Docker server mode is `windows`.
+- Confirm the requested image tag exists locally, or acquire it explicitly.
+- Fail fast on preflight failures and classify them distinctly from runtime LabVIEWCLI failures.
+
+## Certification and Classification
+- Use `examples/build-your-own-image/certify-image-contract.ps1` for image-contract certification.
+- Always persist `builds/status/image-contract-cert-summary-*.json` and associated run logs.
+- Treat missing-image/preflight failures as `verifier_execution_error`.
+
+## 2020 Promotion Guardrail
+- Keep canonical `labview-custom-windows:2020q1-windows` frozen until certification gates pass.
+- Promotion requires two consecutive fresh passes with:
+  - `final_exit_code = 0`
+  - `contains_minus_350000 = false`
+  - `port_listening_before_cli = true`
+
+## Branching and Traceability
+- Prefer feature branches named by issue scope.
+- Reference issues in commit/PR descriptions (for example `Refs #<issue>`).
+- Keep changes minimal and scoped to a single concern per branch whenever possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,111 @@
-# Agent Working Contract
+# Agent Operating Contract
 
 ## Scope
-These instructions apply to this repository (`labview-for-containers`) and should be used by coding agents working in this repo.
+These instructions apply to this repository (`labview-for-containers`) and define how coding agents should execute changes, run validation, and publish evidence.
 
-## Safety Rules
+## Intent
+- Keep delivery moving on deterministic green paths.
+- Stabilize risky lanes without contaminating canonical image tags.
+- Prefer auditable, machine-readable evidence over ad-hoc conclusions.
+
+## Safety and Worktree Discipline
 - Do not run destructive git commands (`reset --hard`, `checkout --`) unless explicitly requested.
-- If the current worktree is dirty, use an isolated git worktree for integration work.
-- Keep evidence logs under `TestResults/agent-logs` and do not delete prior diagnostic bundles unless requested.
+- If the active worktree is dirty, create an isolated worktree for merge/integration tasks.
+- Do not delete prior diagnostics under `TestResults/agent-logs` unless explicitly requested.
+- Keep each branch focused on one concern (for example, certification workflow logic vs docs).
 
 ## Shell and PowerShell Policy
 - Use `powershell -NoProfile -NonInteractive` for Windows script execution.
 - Do not use `-ExecutionPolicy Bypass`.
-- Prefer repository scripts over ad-hoc inline command blocks when a script already exists.
+- Prefer repo scripts over large inline command blocks when a script exists.
 
-## Windows Container Preflight
-Before running Windows image or certification flows:
-- Confirm Docker server mode is `windows`.
-- Confirm the requested image tag exists locally, or acquire it explicitly.
-- Fail fast on preflight failures and classify them distinctly from runtime LabVIEWCLI failures.
+## Deterministic Execution Order
+Run validations in this order and stop at the first failing gate:
+1. Gate 0: Environment preflight
+2. Gate 1: Integration example smoke
+3. Gate 2: Image verifier smoke
+4. Gate 3: Image contract certification
+5. Gate 4: Phase-3/PPL throughput work
 
-## Certification and Classification
-- Use `examples/build-your-own-image/certify-image-contract.ps1` for image-contract certification.
-- Always persist `builds/status/image-contract-cert-summary-*.json` and associated run logs.
-- Treat missing-image/preflight failures as `verifier_execution_error`.
+## Gate Definitions
 
-## 2020 Promotion Guardrail
-- Keep canonical `labview-custom-windows:2020q1-windows` frozen until certification gates pass.
-- Promotion requires two consecutive fresh passes with:
-  - `final_exit_code = 0`
-  - `contains_minus_350000 = false`
-  - `port_listening_before_cli = true`
+### Gate 0: Environment Preflight
+- Verify Docker server mode is `windows` before any Windows image flow.
+- Verify target image availability (inspect; pull/acquire if remote).
+- Verify required local paths/scripts exist before run dispatch.
+- Preflight failures are execution/preparation failures, not CLI runtime failures.
 
-## Branching and Traceability
-- Prefer feature branches named by issue scope.
-- Reference issues in commit/PR descriptions (for example `Refs #<issue>`).
-- Keep changes minimal and scoped to a single concern per branch whenever possible.
+### Gate 1: Integration Example Smoke
+- Use `examples/integration-into-cicd/runlabview.ps1`.
+- Always pass explicit `-LabVIEWYear` or explicit `-LabVIEWPath`.
+- Treat default-year assumptions as unsafe when image year differs.
+
+### Gate 2: Image Verifier Smoke
+- Use `examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1`.
+- Use explicit `-LvYear` and `-LvCliPort`.
+- Capture and preserve diagnostics (summary, netstat, process list, INI snapshots, temporary logs).
+
+### Gate 3: Image Contract Certification
+- Use `examples/build-your-own-image/certify-image-contract.ps1`.
+- Publish and preserve `builds/status/image-contract-cert-summary-*.json`.
+- Certification classification is authoritative for pass/fail decisions.
+
+### Gate 4: Phase-3/PPL Throughput
+- Start only after Gate 3 (or explicit exception approved in issue/PR).
+- Throughput track must not silently alter 2020 promotion policy.
+
+## Split-Track Strategy
+
+### Track A: 2026 Throughput
+- Objective: keep artifact throughput green.
+- Expected lane: hosted 2022.
+- Acceptable for delivery while 2020 stabilization is ongoing.
+
+### Track B: 2020 Stabilization
+- Objective: remove non-determinism and satisfy promotion gate.
+- Prefer self-hosted real Server 2019 lane for promotion eligibility.
+- Keep canonical `labview-custom-windows:2020q1-windows` frozen until gate passes.
+
+## Promotion Guardrail (2020 Canonical Tag)
+Do not retag canonical 2020 image unless two consecutive fresh runs satisfy all:
+- `final_exit_code = 0`
+- `contains_minus_350000 = false`
+- `port_listening_before_cli = true`
+- certification summary indicates promotion eligibility.
+
+## Failure Taxonomy and First Response
+- `environment_incompatible`
+  - Fix runner/OS lane first; do not tune image yet.
+- `verifier_execution_error`
+  - Fix preflight/acquisition/script execution path first.
+- `port_not_listening`
+  - Focus on LabVIEW readiness/launch timing and listener diagnostics.
+- `cli_connect_fail`
+  - Focus on CLI-to-LabVIEW connectivity and retry semantics.
+
+## Headless Runtime Rules
+- Headless and interactive IDE sessions are mutually exclusive.
+- If a UI/IDE session was launched, close it before headless CLI automation.
+- Prefer passing `-Headless` explicitly for clarity/reliability.
+- For triage, always capture console output plus LabVIEW/LabVIEWCLI logs.
+
+## Evidence Contract
+For every non-trivial run, persist:
+- run command/context
+- output summary JSON
+- key diagnostics (`netstat`, process list, INI snapshots, temp logs)
+- link to workflow run URL when run in CI
+- classification and next action in one short conclusion
+
+## GitHub Workflow and Issue Discipline
+- Reference issue IDs in commit messages/PR descriptions (`Refs #<issue>`).
+- Document classification outcomes in issue comments with artifact paths.
+- If an issue is already closed, open a new issue for new scope rather than overloading the closed one.
+
+## Source-of-Truth Files
+- `docs/windows-custom-images.md`
+- `docs/faqs.md`
+- `.github/workflows/labview-image-contract-certification.yml`
+- `examples/build-your-own-image/certify-image-contract.ps1`
+- `examples/build-your-own-image/verify-lv-cli-masscompile-from-image.ps1`
+- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`

--- a/Tooling/Assert-ImageCertificationEvidence.ps1
+++ b/Tooling/Assert-ImageCertificationEvidence.ps1
@@ -1,0 +1,170 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$SummaryPath,
+    [string]$ExpectedContractProfile = '',
+    [string]$ExpectedImageTag = '',
+    [int]$MinRepeatRuns = 1,
+    [switch]$RequireLocalSourceLogPaths
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-HasProperty {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if (-not $Object.PSObject.Properties.Name.Contains($Name)) {
+        throw "Missing required property '$Name'."
+    }
+}
+
+function Assert-StringNotBlank {
+    param(
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "Property '$Name' must be a non-empty string."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
+    throw 'SummaryPath is empty. Certification did not produce a summary file path.'
+}
+
+if (-not (Test-Path -LiteralPath $SummaryPath -PathType Leaf)) {
+    throw "Summary file not found: $SummaryPath"
+}
+
+$summary = Get-Content -LiteralPath $SummaryPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+
+$requiredTop = @(
+    'schema_version',
+    'generated_utc',
+    'contract_profile',
+    'image_tag',
+    'runner_fingerprint',
+    'verification_metrics',
+    'classification',
+    'promotion_eligible',
+    'reasons',
+    'source_log_paths'
+)
+foreach ($name in $requiredTop) {
+    Assert-HasProperty -Object $summary -Name $name
+}
+
+Assert-StringNotBlank -Value ([string]$summary.schema_version) -Name 'schema_version'
+Assert-StringNotBlank -Value ([string]$summary.generated_utc) -Name 'generated_utc'
+Assert-StringNotBlank -Value ([string]$summary.contract_profile) -Name 'contract_profile'
+Assert-StringNotBlank -Value ([string]$summary.image_tag) -Name 'image_tag'
+Assert-StringNotBlank -Value ([string]$summary.classification) -Name 'classification'
+
+if (-not [string]::IsNullOrWhiteSpace($ExpectedContractProfile) -and [string]$summary.contract_profile -ne $ExpectedContractProfile) {
+    throw "contract_profile mismatch. expected='$ExpectedContractProfile' actual='$($summary.contract_profile)'"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedImageTag) -and [string]$summary.image_tag -ne $ExpectedImageTag) {
+    throw "image_tag mismatch. expected='$ExpectedImageTag' actual='$($summary.image_tag)'"
+}
+
+$allowedClassifications = @(
+    'pass',
+    'port_not_listening',
+    'cli_connect_fail',
+    'environment_incompatible',
+    'verifier_execution_error'
+)
+if ($allowedClassifications -notcontains [string]$summary.classification) {
+    throw "classification '$($summary.classification)' is not in allowed set: $($allowedClassifications -join ', ')"
+}
+
+$metrics = $summary.verification_metrics
+$requiredMetrics = @(
+    'repeat_runs_requested',
+    'runs_completed',
+    'pass_count',
+    'failure_count',
+    'all_runs_port_listening',
+    'any_minus_350000',
+    'has_preflight_or_execution_error',
+    'has_missing_image_error',
+    'run_results'
+)
+foreach ($name in $requiredMetrics) {
+    Assert-HasProperty -Object $metrics -Name $name
+}
+
+$effectiveMinRepeatRuns = if ($MinRepeatRuns -gt 0) { $MinRepeatRuns } else { 1 }
+$repeatRunsRequested = [int]$metrics.repeat_runs_requested
+$runsCompleted = [int]$metrics.runs_completed
+$passCount = [int]$metrics.pass_count
+$failureCount = [int]$metrics.failure_count
+$runResults = @($metrics.run_results)
+
+if ($repeatRunsRequested -lt $effectiveMinRepeatRuns) {
+    throw "repeat_runs_requested ($repeatRunsRequested) is below required minimum ($effectiveMinRepeatRuns)."
+}
+if ($runsCompleted -lt 1) {
+    throw "runs_completed must be >= 1. Actual: $runsCompleted"
+}
+if ($runsCompleted -ne $runResults.Count) {
+    throw "runs_completed ($runsCompleted) must match run_results count ($($runResults.Count))."
+}
+if (($passCount + $failureCount) -ne $runsCompleted) {
+    throw "pass_count + failure_count must equal runs_completed. pass_count=$passCount failure_count=$failureCount runs_completed=$runsCompleted"
+}
+
+if ($summary.reasons -isnot [System.Collections.IEnumerable] -or @($summary.reasons).Count -lt 1) {
+    throw 'reasons must contain at least one entry.'
+}
+if ($summary.source_log_paths -isnot [System.Collections.IEnumerable] -or @($summary.source_log_paths).Count -lt 1) {
+    throw 'source_log_paths must contain at least one entry.'
+}
+
+$missingSourcePaths = New-Object System.Collections.Generic.List[string]
+if ($RequireLocalSourceLogPaths) {
+    foreach ($path in @($summary.source_log_paths)) {
+        if ([string]::IsNullOrWhiteSpace([string]$path)) {
+            continue
+        }
+        if (-not (Test-Path -LiteralPath ([string]$path))) {
+            $missingSourcePaths.Add([string]$path) | Out-Null
+        }
+    }
+}
+
+$requiredRunResultProperties = @(
+    'run_index',
+    'pass',
+    'summary_path',
+    'final_exit_code',
+    'contains_minus_350000',
+    'port_listening_before_cli',
+    'error',
+    'logs_path'
+)
+foreach ($runResult in $runResults) {
+    foreach ($propertyName in $requiredRunResultProperties) {
+        Assert-HasProperty -Object $runResult -Name $propertyName
+    }
+}
+
+if ([string]$summary.classification -eq 'pass') {
+    if ($passCount -ne $runsCompleted) {
+        throw "classification=pass requires pass_count == runs_completed. pass_count=$passCount runs_completed=$runsCompleted"
+    }
+    if (-not [bool]$summary.promotion_eligible) {
+        throw 'classification=pass requires promotion_eligible=true.'
+    }
+}
+
+if ($missingSourcePaths.Count -gt 0) {
+    throw "Missing local source_log_paths detected: $($missingSourcePaths -join '; ')"
+}
+
+Write-Host "Certification evidence contract verified: $SummaryPath"
+Write-Host "classification=$($summary.classification); runs_completed=$runsCompleted; pass_count=$passCount; failure_count=$failureCount"

--- a/Tooling/image-cert-summary.schema.json
+++ b/Tooling/image-cert-summary.schema.json
@@ -66,6 +66,8 @@
         "failure_count",
         "all_runs_port_listening",
         "any_minus_350000",
+        "has_preflight_or_execution_error",
+        "has_missing_image_error",
         "run_results"
       ],
       "properties": {
@@ -85,6 +87,12 @@
           "type": "boolean"
         },
         "any_minus_350000": {
+          "type": "boolean"
+        },
+        "has_preflight_or_execution_error": {
+          "type": "boolean"
+        },
+        "has_missing_image_error": {
           "type": "boolean"
         },
         "run_results": {

--- a/docs/build-your-own-image.md
+++ b/docs/build-your-own-image.md
@@ -4,6 +4,7 @@ This document is an entry point for building **custom LabVIEW container images**
 
 - [Building Your Own LabVIEW Linux Container Image](./linux-custom-images.md)
 - [Building Your Own LabVIEW Windows Container Image](./windows-custom-images.md)
+- [Windows Custom Images Operations (Fork)](./windows-custom-images-operations.md)
 
 Use these guides if you need more control than the prebuilt images provide—for example, to:
 - Install additional software or dependencies
@@ -29,3 +30,4 @@ For general information about supported base images and headless operation, see:
 
 - If you are targeting **Linux containers**, continue with: [Building Your Own LabVIEW Linux Container Image](./linux-custom-images.md)
 - If you are targeting **Windows containers**, continue with: [Building Your Own LabVIEW Windows Container Image](./windows-custom-images.md)
+- If you need this fork's stabilization/promotion runbooks, continue with: [Windows Custom Images Operations (Fork)](./windows-custom-images-operations.md)

--- a/docs/windows-custom-images-operations.md
+++ b/docs/windows-custom-images-operations.md
@@ -1,0 +1,496 @@
+# Windows Custom Images Operations (Fork)
+
+This runbook contains fork-specific operational workflows for Windows custom
+images and certification.
+It complements the canonical guide in
+[Building Your Own LabVIEW Windows Container Image](./windows-custom-images.md).
+
+This guide covers the `lv2020x64` Windows custom-image workflow in this fork.
+It includes a resumable build path for installs that return reboot-required
+(`Error -125071`).
+
+Use this approach if you need to:
+
+- Iterate locally with LabVIEW 2020 x64 and LabVIEWCLI.
+- Avoid repeating full install work when NI Package Manager requests restart.
+- Keep image build inputs explicit and reproducible.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Default lv2020x64 Contract](#default-lv2020x64-contract)
+- [Fast Path: Dockerfile-Only Build](#fast-path-dockerfile-only-build)
+- [Restart-Aware Path (Recommended for -125071)](#restart-aware-path-recommended-for--125071)
+- [Confirm Baseline with Built-In MassCompile (No Clone)](#confirm-baseline-with-built-in-masscompile-no-clone)
+- [Troubleshooting Reboot-Required Installs](#troubleshooting-reboot-required-installs)
+- [Phase 3 Local PPL From Known Image](#phase-3-local-ppl-from-known-image)
+- [Troubleshooting Phase 3 PPL Builds](#troubleshooting-phase-3-ppl-builds)
+- [Split-Track Execution (2026 Throughput + 2020 Stabilization)](#split-track-execution-2026-throughput--2020-stabilization)
+- [Dedicated Validation Host Policy](#dedicated-validation-host-policy)
+- [Image Contract Certification](#image-contract-certification)
+- [2020 Promotion Freeze and Gate (Deferred)](#2020-promotion-freeze-and-gate-deferred)
+- [Engineered Prompt Template (lv2020x64)](#engineered-prompt-template-lv2020x64)
+- [Final Notes](#final-notes)
+
+## Prerequisites
+
+Before building your own Windows image, make sure you have:
+
+- A Windows host with Docker configured for **Windows containers**.
+- Internet access from host and container to `download.ni.com`.
+- Access to NI Package Manager (NIPKG) feeds and installers.
+- This fork's workflow files:
+  `examples/build-your-own-image/Dockerfile-windows`
+- `examples/build-your-own-image/Resources/Windows Resources/Install-LV2020x64.ps1`
+- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`
+
+## Default lv2020x64 Contract
+
+`examples/build-your-own-image/Dockerfile-windows` defaults to:
+
+```dockerfile
+ARG LV_YEAR=2020
+ARG LV_FEED_LOCATION=
+ARG LV_CORE_PACKAGE=ni-labview-2020-core-en
+ARG LV_CLI_PACKAGE=ni-labview-command-line-interface-x86
+ARG LV_CLI_PORT=3363
+ARG INSTALL_OPTIONAL_HELP=0
+ARG DEFER_LV_INSTALL=0
+```
+
+Key behavior:
+
+- `LV_FEED_LOCATION` is required when `DEFER_LV_INSTALL=0`.
+- Mandatory packages fail hard when package IDs are invalid.
+- `INSTALL_OPTIONAL_HELP=0` skips optional help package install.
+- `LV_CLI_PORT` is applied to:
+  `LabVIEW.ini` (`server.tcp.port`) and
+  `LabVIEWCLI.ini` (`DefaultPortNumber`).
+- `DEFER_LV_INSTALL=1` builds a seed image without LV package install.
+
+## Fast Path: Dockerfile-Only Build
+
+Use this when install completes in one pass (no reboot checkpoint):
+
+```powershell
+cd .\examples\build-your-own-image
+
+$lvFeed = 'https://download.ni.com/support/nipkg/products/ni-l/' +
+  'ni-labview-2020/20.0/released'
+
+docker build -t labview-custom-windows:2020q1-windows -f Dockerfile-windows `
+  --build-arg LV_FEED_LOCATION=$lvFeed `
+  --build-arg LV_CLI_PORT=3363 `
+  --build-arg INSTALL_OPTIONAL_HELP=0
+```
+
+If the build succeeds, verify image presence:
+
+```powershell
+docker images
+```
+
+## Restart-Aware Path (Recommended for -125071)
+
+Use this path when NIPKG reports reboot-required (`Error -125071`).
+This flow persists checkpoint state in a Docker volume and resumes through a
+phase loop (`phase1..phaseN`) until completion or checkpoint failure.
+
+Script:
+
+- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`
+
+Parameters:
+
+- `-ImageTag` default `labview-custom-windows:2020q1-windows`
+- `-LvFeedLocation` required
+- `-PersistVolumeName` default `vm`
+- `-DnsServer` default `1.1.1.1`
+- `-NipmInstallerDownloadUrl` default
+  `https://download.ni.com/support/nipkg/products/ni-package-manager/installers/NIPackageManager26.0.0.exe`
+- `-NipmInstallerDownloadSha256` default
+  `A2AF381482F85ABA2A963676EAC436F96D69572A9EBFBAF85FF26C372A1995C3`
+- `-NipmInstallerSourcePath` optional host file override
+- `-Phase1Tag` and `-Phase2Tag` optional overrides
+- `-KeepIntermediate` optional switch
+- `-MaxResumePhases` default `4`
+
+Run:
+
+```powershell
+cd .\examples\build-your-own-image
+
+$lvFeed = 'https://download.ni.com/support/nipkg/products/ni-l/' +
+  'ni-labview-2020/20.0/released'
+
+pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
+  -LvFeedLocation $lvFeed `
+  -PersistVolumeName vm
+```
+
+What the script does:
+
+1. Validates branch is `lv2020x64`.
+1. Verifies Docker is in Windows container mode.
+1. Ensures
+   `examples/build-your-own-image/Resources/Windows Resources/install.exe`
+   exists by using the first valid source:
+   - existing local file
+   - `-NipmInstallerSourcePath` (if supplied)
+   - download from `-NipmInstallerDownloadUrl`
+1. Prints SHA256 for the installer file used.
+1. Ensures the named volume exists (creates it when missing).
+1. Uses `--dns` for phase containers (default `1.1.1.1`).
+1. Builds a seed image with `DEFER_LV_INSTALL=1`.
+1. Runs install in `phase1..phaseN` containers with `-v vm:C:\lv-persist`.
+1. On each `194`, commits a checkpoint image `...-phase<index>` and resumes.
+1. Detects stuck reboot checkpoints when consecutive phases return `194` with
+   unchanged `resume_cursor` and package step.
+1. Stops at success (`0`) or when `-MaxResumePhases` is exceeded.
+1. Writes build summary JSON to `builds/status/lv2020x64-build-summary-*.json`.
+1. Enforces `LV_CLI_PORT=3363`; other values fail fast.
+
+## Confirm Baseline with Built-In MassCompile (No Clone)
+
+Use this check to verify image baseline behavior without mounting external repos.
+
+```powershell
+docker run --rm labview-custom-windows:2020q1-windows `
+  powershell -NoProfile -Command `
+  "LabVIEWCLI -LabVIEWPath 'C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe' -OperationName MassCompile -DirectoryToCompile 'C:\Program Files\National Instruments\LabVIEW 2020\examples\Arrays' -PortNumber 3363 -Headless"
+```
+
+Expected result:
+
+- Command exits `0`.
+- No `-350000` in output.
+
+Checkpoint artifacts written to the volume:
+
+- `C:\lv-persist\state.json`
+- `C:\lv-persist\install.log`
+
+## Troubleshooting Reboot-Required Installs
+
+### Error `-125071` During Install
+
+If you see:
+
+- `Error -125071: A system reboot is needed to complete the transaction.`
+
+Actions:
+
+1. Use the resumable script instead of Dockerfile-only build.
+1. Keep `-PersistVolumeName vm` so state survives phase transitions.
+1. Inspect checkpoint state:
+
+```powershell
+docker run --rm -v vm:C:\lv-persist mcr.microsoft.com/windows/server:ltsc2022 `
+  powershell -NoProfile -Command "Get-Content C:\lv-persist\state.json"
+```
+
+1. If phase 2 still exits `194`, rerun with `-KeepIntermediate` and inspect
+   `builds/status/lv2020x64-build-summary-*.json` for checkpoint cursor and
+   outcome classification before retrying.
+
+### Missing Feed Location
+
+If build fails with missing feed location:
+
+- Pass `--build-arg LV_FEED_LOCATION=<feed-url>` for Dockerfile-only.
+- Pass `-LvFeedLocation <feed-url>` for the resumable script.
+- Recommended value for this 2020 scope:
+  `https://download.ni.com/support/nipkg/products/ni-l/ni-labview-2020/20.0/released`
+- Do not use local raw metadata folders such as
+  `C:\ProgramData\National Instruments\NI Package Manager\raw\...` as a direct
+  `feed-add` source; they are not valid feed URIs for this workflow.
+
+### Missing Installer Bootstrapper
+
+If build fails before seed image creation due to a missing installer bootstrapper:
+
+1. Rerun with explicit download URL/SHA overrides when needed:
+
+```powershell
+$nipmUrl = 'https://download.ni.com/support/nipkg/products/' +
+  'ni-package-manager/' +
+  'installers/NIPackageManager26.0.0.exe'
+$nipmSha256 = 'A2AF381482F85ABA2A963676EAC436F96D69572A9EBFBAF85FF26C372A1995C3'
+
+pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
+  -LvFeedLocation $lvFeed `
+  -NipmInstallerDownloadUrl $nipmUrl `
+  -NipmInstallerDownloadSha256 $nipmSha256 `
+  -PersistVolumeName vm
+```
+
+1. If download is unavailable, pass a host file directly:
+
+```powershell
+pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
+  -LvFeedLocation $lvFeed `
+  -NipmInstallerSourcePath "D:\Installers\NIPM\install.exe" `
+  -PersistVolumeName vm
+```
+
+1. If the container cannot resolve `download.ni.com`, set a reachable DNS server:
+
+```powershell
+pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
+  -LvFeedLocation $lvFeed `
+  -DnsServer 1.1.1.1 `
+  -PersistVolumeName vm
+```
+
+### Port Contract Mismatch
+
+If CLI cannot connect:
+
+1. Confirm build arg `LV_CLI_PORT`.
+1. Verify final in-image files:
+   - `C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.ini`
+   - `C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini`
+
+
+## Phase 3 Local PPL From Known Image
+
+Use this path to build `lv_icon.lvlibp` from an already-built x64 image.
+
+Script:
+
+- `examples/build-your-own-image/build-lv-icon-ppl-from-image.ps1`
+
+Inputs:
+
+- `-ImageTag` default `labview-custom-windows:2020q1-windows-phase2`
+- `-IconEditorRepoRoot` optional; auto-resolves sibling icon-editor repo
+- `-LvYear` default `2020`
+- `-LvCliPort` default `3363`
+- `-BuildSpecName` default `Editor Packed Library`
+- `-OutputRelativePath` default `resource/plugins/lv_icon.lvlibp`
+- `-KeepContainer` optional switch
+- `-LogRoot` optional override for log output root
+
+Happy path:
+
+```powershell
+cd .\examples\build-your-own-image
+
+pwsh -NoProfile -File .\build-lv-icon-ppl-from-image.ps1 `
+  -ImageTag labview-custom-windows:2020q1-windows-phase2
+```
+
+Debug path (keep failed container):
+
+```powershell
+pwsh -NoProfile -File .\build-lv-icon-ppl-from-image.ps1 `
+  -ImageTag labview-custom-windows:2020q1-windows-phase2 `
+  -KeepContainer
+```
+
+Expected outputs:
+
+- PPL artifact: `<icon-editor-root>\resource\plugins\lv_icon.lvlibp`
+- Logs: `TestResults\agent-logs\ppl-phase3-<timestamp>\`
+- Summary: `summary.json` inside the run log folder
+
+## Troubleshooting Phase 3 PPL Builds
+
+### `-350000` LabVIEWCLI Connection Failure
+
+If you see CLI connection failures:
+
+1. Open run summary/logs under `TestResults\agent-logs\ppl-phase3-<timestamp>\`.
+1. Check `phase3-diag\port-listening.txt` and `phase3-diag\netstat-ano.txt`.
+1. Verify copied INI files under `phase3-diag\LabVIEW.ini` and `phase3-diag\LabVIEWCLI.ini`.
+1. Re-run with `-KeepContainer` to preserve state for manual inspection.
+
+### Missing Artifact With Zero-Like CLI Output
+
+If `ExecuteBuildSpec` appears to run but output is missing:
+
+1. Confirm `BuildSpecName` matches the project build spec.
+1. Confirm `OutputRelativePath` matches expected output location.
+1. Review `executebuildspec.log` and `collect-diagnostics.log` in the same run folder.
+
+## Split-Track Execution (2026 Throughput + 2020 Stabilization)
+
+Use this fork's split-track policy:
+
+- Throughput track: run Phase 3 artifact production against
+  `nationalinstruments/labview:2026q1-windows`.
+- Stabilization track: isolate LabVIEW 2020 diagnostics in a separate manual workflow.
+- Do not retag/publish `labview-custom-windows:2020q1-windows` in this pass.
+
+Local 2026 throughput wrapper:
+
+- `examples/build-your-own-image/run-phase3-throughput-2026.ps1`
+
+Wrapper contract:
+
+- `-IconEditorRepoRoot`
+- `-OutputRelativePath`
+- `-LvCliPort` (must be `3363`)
+- `-KeepContainer`
+- `-LogRoot`
+
+Run two consecutive executions (required for local repeatability):
+
+```powershell
+cd .\examples\build-your-own-image
+
+$iconRepo = 'D:\workspace\labview-icon-editor\labview-icon-editor'
+
+pwsh -NoProfile -File .\run-phase3-throughput-2026.ps1 `
+  -IconEditorRepoRoot $iconRepo
+
+pwsh -NoProfile -File .\run-phase3-throughput-2026.ps1 `
+  -IconEditorRepoRoot $iconRepo
+```
+
+Success criteria:
+
+- both runs exit `0`
+- both runs produce non-empty `resource\plugins\lv_icon.lvlibp`
+- each run writes a `summary.json` under
+  `TestResults\agent-logs\phase3-throughput-2026-<timestamp>\ppl-phase3-<timestamp>\`
+
+Conservative cleanup after runs:
+
+```powershell
+pwsh -NoProfile -File .\cleanup-windows-docker-artifacts.ps1 `
+  -Mode Conservative -Apply
+```
+
+Manual 2020 stabilization workflow:
+
+- `.github/workflows/labview-2020-stabilization-matrix.yml`
+
+Workflow inputs:
+
+- `image_tag`
+- `lv_year`
+- `lv_cli_port`
+- `runner_target`
+- `base_matrix`
+- `isolation_mode`
+- `max_cli_attempts`
+
+Stabilization outcomes:
+
+- `pass`
+- `port_not_listening`
+- `cli_connect_fail`
+- `environment_incompatible`
+
+Each run uploads a diagnostic artifact bundle containing `summary.json`,
+MassCompile logs, `lvtemporary_*`, netstat/process snapshots, and INI copies.
+
+## Dedicated Validation Host Policy
+
+For dedicated self-hosted Windows validation machines, use the host policy and
+enforcement runbook in:
+
+- `docs/labview-container-parity.md`
+
+Key rule: do not infer target year from the `LabVIEWCLI` binary version.
+Always pass explicit `LabVIEWPath` and `PortNumber` for operations.
+
+## Image Contract Certification
+
+Use this dedicated certification surface to produce machine-readable image
+contract evidence:
+
+- Profiles: `Tooling/image-contract-profiles.json`
+- Summary schema: `Tooling/image-cert-summary.schema.json`
+- Script: `examples/build-your-own-image/certify-image-contract.ps1`
+- Workflow: `.github/workflows/labview-image-contract-certification.yml`
+
+Certification runs aggregate repeated verifier passes and emit:
+
+- `builds/status/image-contract-cert-summary-*.json`
+- per-run diagnostics in `TestResults/agent-logs/certification-*`
+
+Manual workflow inputs:
+
+- `contract_profile`
+- `image_tag`
+- `runner_target`
+- `isolation_mode`
+- `max_cli_attempts`
+- `repeat_runs`
+
+For `2020-x64-stabilization`, certification may run on hosted lanes for
+diagnostics, but `promotion_eligible` remains `false` unless runner
+fingerprint indicates a real Server 2019 lane.
+
+Comparison procedure (triage discipline):
+
+1. Open previous failing references (`22262096511`, `22262277660`, `22262448572`).
+1. Compare classification and verifier metrics against latest
+   `image-contract-cert-summary-*.json`.
+1. Confirm whether failure is `port_not_listening`, `cli_connect_fail`, or
+   `environment_incompatible` before changing install/runtime settings.
+
+## 2020 Promotion Freeze and Gate (Deferred)
+
+Promotion remains blocked for `labview-custom-windows:2020q1-windows` until
+one real Server 2019 lane passes two fresh runs with all of:
+
+- `final_exit_code=0`
+- `contains_minus_350000=false`
+- `port_listening_before_cli=true`
+- `promotion_eligible=true` in certification summary
+
+Only after that gate:
+
+1. create a backup tag for the current canonical image
+1. retag validated candidate to `labview-custom-windows:2020q1-windows`
+
+If any gate fails, keep candidate tags only and continue stabilization without
+retagging canonical.
+
+## Engineered Prompt Template (lv2020x64)
+
+Use this prompt to ask an AI assistant for reproducible updates:
+
+```text
+You are editing a fork at path `labview-for-containers-fork`
+on branch `lv2020x64`.
+
+Goal:
+- Produce a deterministic local Windows image for LabVIEW 2020 x64 + LabVIEWCLI.
+- Optimize for iterative local development speed.
+- Support resumable install when NIPKG reports reboot-required (`Error -125071`).
+
+Hard requirements:
+1) Keep these defaults:
+   - LV_YEAR=2020
+   - LV_CORE_PACKAGE=ni-labview-2020-core-en
+   - LV_CLI_PACKAGE=ni-labview-command-line-interface-x86
+   - LV_CLI_PORT=3363
+   - INSTALL_OPTIONAL_HELP=0
+2) Treat LV_FEED_LOCATION as required for non-deferred install paths.
+3) Mandatory packages must fail hard if package IDs are invalid.
+4) Update both LabVIEW.ini and LabVIEWCLI.ini port settings from LV_CLI_PORT.
+5) Keep a resumable flow that uses Docker volume `vm` (overridable)
+   and exits 194 for reboot checkpoints.
+6) Preserve and extend existing unstaged edits; do not discard them.
+
+Expected outputs:
+- Updated Dockerfile-windows.
+- Updated/reusable resumable host script.
+- Updated in-container installer script.
+- Updated docs with fast path + restart-aware path + troubleshooting.
+- Validation commands to syntax-check PowerShell and verify doc commands.
+```
+
+## Final Notes
+
+1. Windows container images run only on Windows hosts in Windows mode.
+1. All LabVIEW operations in these containers should use `LabVIEWCLI`.
+1. `examples/integration-into-cicd/runlabview.ps1` now defaults to `2020`.
+1. If you change package IDs or args, retag resulting images for traceability.
+1. For additional headless guidance, see:
+   - [Windows Prebuilt Images](./windows-prebuilt.md)
+   - [Headless LabVIEW](./headless-labview.md)

--- a/docs/windows-custom-images.md
+++ b/docs/windows-custom-images.md
@@ -1,491 +1,170 @@
 # Building Your Own LabVIEW Windows Container Image
 
-This guide covers the `lv2020x64` Windows custom-image workflow in this fork.
-It includes a resumable build path for installs that return reboot-required
-(`Error -125071`).
+This guide provides instructions for building your own LabVIEW Windows container image using the official Windows Dockerfile and resources in this repository.
 
 Use this approach if you need to:
+- Install additional Windows tools or dependencies alongside LabVIEW
+- Include custom scripts or test frameworks
+- Configure a Windows-based CI/CD environment where LabVIEW runs headlessly inside a Windows container
 
-- Iterate locally with LabVIEW 2020 x64 and LabVIEWCLI.
-- Avoid repeating full install work when NI Package Manager requests restart.
-- Keep image build inputs explicit and reproducible.
+For fork-specific operational runbooks (2026 throughput gating, 2020 stabilization, certification policy), see [Windows Custom Images Operations](./windows-custom-images-operations.md).
 
 ## Table of Contents
-
 - [Prerequisites](#prerequisites)
-- [Default lv2020x64 Contract](#default-lv2020x64-contract)
-- [Fast Path: Dockerfile-Only Build](#fast-path-dockerfile-only-build)
-- [Restart-Aware Path (Recommended for -125071)](#restart-aware-path-recommended-for--125071)
-- [Confirm Baseline with Built-In MassCompile (No Clone)](#confirm-baseline-with-built-in-masscompile-no-clone)
-- [Troubleshooting Reboot-Required Installs](#troubleshooting-reboot-required-installs)
-- [Phase 3 Local PPL From Known Image](#phase-3-local-ppl-from-known-image)
-- [Troubleshooting Phase 3 PPL Builds](#troubleshooting-phase-3-ppl-builds)
-- [Split-Track Execution (2026 Throughput + 2020 Stabilization)](#split-track-execution-2026-throughput--2020-stabilization)
-- [Dedicated Validation Host Policy](#dedicated-validation-host-policy)
-- [Image Contract Certification](#image-contract-certification)
-- [2020 Promotion Freeze and Gate (Deferred)](#2020-promotion-freeze-and-gate-deferred)
-- [Engineered Prompt Template (lv2020x64)](#engineered-prompt-template-lv2020x64)
+- [Important Considerations](#important-considerations)
+- [Dockerfile Overview](#dockerfile-overview)
+- [How to Build the Image](#how-to-build-the-image)
 - [Final Notes](#final-notes)
 
 ## Prerequisites
 
 Before building your own Windows image, make sure you have:
 
-- A Windows host with Docker configured for **Windows containers**.
-- Internet access from host and container to `download.ni.com`.
-- Access to NI Package Manager (NIPKG) feeds and installers.
-- This fork's workflow files:
-  `examples/build-your-own-image/Dockerfile-windows`
-- `examples/build-your-own-image/Resources/Windows Resources/Install-LV2020x64.ps1`
-- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`
+- A compatible Windows host with Docker installed and configured for **Windows containers**
+- Permissions to run Windows Server Core–based images (for example, `mcr.microsoft.com/windows/server:ltsc2022`)
+- Access to NI Package Manager (NIPKG) offline installers and the appropriate LabVIEW feeds
+- A working internet connection if you rely on external feeds (optional if entirely offline)
+- Access to the official Windows Dockerfile, located at: [examples/build-your-own-image/Dockerfile-windows](../examples/build-your-own-image/Dockerfile-windows)
 
-## Default lv2020x64 Contract
+## Important Considerations
 
-`examples/build-your-own-image/Dockerfile-windows` defaults to:
+- These images are based on a Windows Server image and are intended for **headless** LabVIEW use.
+- All interactions with LabVIEW inside the container should be performed using **LabVIEWCLI**.
+- When running LabVIEWCLI in Windows containers for LabVIEW 2026 Q1 and later, you must use the `-Headless` argument as described in the [Windows Prebuilt Images](./windows-prebuilt.md) documentation.
 
-```dockerfile
-ARG LV_YEAR=2020
-ARG LV_FEED_LOCATION=
-ARG LV_CORE_PACKAGE=ni-labview-2020-core-en
-ARG LV_CLI_PACKAGE=ni-labview-command-line-interface-x86
-ARG LV_CLI_PORT=3363
-ARG INSTALL_OPTIONAL_HELP=0
-ARG DEFER_LV_INSTALL=0
-```
+## Dockerfile Overview
 
-Key behavior:
+The Windows Dockerfile at `examples/build-your-own-image/Dockerfile-windows` performs the following key tasks.
 
-- `LV_FEED_LOCATION` is required when `DEFER_LV_INSTALL=0`.
-- Mandatory packages fail hard when package IDs are invalid.
-- `INSTALL_OPTIONAL_HELP=0` skips optional help package install.
-- `LV_CLI_PORT` is applied to:
-  `LabVIEW.ini` (`server.tcp.port`) and
-  `LabVIEWCLI.ini` (`DefaultPortNumber`).
-- `DEFER_LV_INSTALL=1` builds a seed image without LV package install.
+1. **Base Image and LabVIEW Year**
+   ```dockerfile
+   FROM mcr.microsoft.com/windows/server:ltsc2022
 
-## Fast Path: Dockerfile-Only Build
+   ARG LV_YEAR=2026
+   ARG LV_FEED_LOCATION=http://argohttp.natinst.com/ni/nipkg/feeds/ni-l/ni-labview-2026/26.1.0/26.1.0.738-0+d738/offline
+   ENV LV_YEAR=${LV_YEAR}
+   ENV LV_FEED_LOCATION=${LV_FEED_LOCATION}
+   ```
+   - Uses a Windows Server LTSC 2022 base image.
+   - Exposes `LV_YEAR` and `LV_FEED_LOCATION` as build arguments and environment variables.
+   - `LV_FEED_LOCATION` should point to a valid NI feed containing the desired LabVIEW version.
 
-Use this when install completes in one pass (no reboot checkpoint):
+2. **Configure PowerShell for Automated Installation**
+   ```dockerfile
+   SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Continue'; $ProgressPreference = 'SilentlyContinue'; $ConfirmPreference = 'None'; $VerbosePreference = 'Continue'; $WarningPreference = 'Continue';"]
+   ```
+   - Configures PowerShell preferences to enable automated, unattended installs.
+
+3. **Prepare Installer Resources**
+   ```dockerfile
+   RUN New-Item -ItemType Directory -Path 'C:\\ni\\resources' -Force
+   COPY ["Resources/Windows Resources", "C:/ni/resources/"]
+   ```
+   - Creates a temporary folder for installers.
+   - Copies Windows installer resources from `Resources/Windows Resources` into the image (for example, NI Package Manager bootstrapper and LabVIEW.ini template).
+   - **You would have to place the NI Package Manager installer and name it as install.exe under `Resources/Windows Resources`.**
+
+4. **Install NI Package Manager (NIPKG)**
+   ```dockerfile
+   RUN Start-Process -wait C:\\ni\\resources\\install.exe -ArgumentList '--passive', '--accept-eulas', '--no-shortcuts', '--no-start-menu', '--no-desktop-icon', '--no-update-check', '--prevent-reboot'
+   ```
+   - Installs NI Package Manager in passive mode, accepting EULAs and preventing reboots.
+
+5. **Add NIPKG to PATH**
+   ```dockerfile
+   RUN setx PATH "%PATH%;C:\\Program Files\\National Instruments\\NI Package Manager"
+   ```
+   - Ensures `nipkg` is available on the PATH for later steps.
+
+6. **Install LabVIEW and Tooling Using NIPKG**
+   ```dockerfile
+   SHELL ["cmd", "/S", "/C"]
+   RUN (nipkg feed-add --name=LV%LV_YEAR% %LV_FEED_LOCATION%) && \
+       (nipkg feed-update) && \
+       (nipkg install --accept-eulas -y ni-offline-help-viewer        || echo "ni-offline-help-viewer failed (ignored)") && \
+       (nipkg install --accept-eulas -y ni-labview-%LV_YEAR%-core-en  || echo "ni-labview-core failed (ignored)") && \
+       (nipkg install --accept-eulas -y ni-viawin-labview-support     || echo "ni-viawin-labview-support failed (ignored)") && \
+       (nipkg install --accept-eulas -y ni-labview-command-line-interface-x86  || echo "ni-labview-command-line-interface-x86 failed (ignored)") && \
+       (nipkg feed-remove LV%LV_YEAR%) && \
+       (nipkg feed-update) && \
+       rmdir /S /Q "C:\ProgramData\National Instruments\NI Package Manager\packages"
+   ```
+   - Switches to `cmd` for compatibility with `nipkg` commands.
+   - Combines all package management operations into a single RUN command:
+     - Adds the LabVIEW feed to the local NIPKG repository
+     - Updates feed information
+     - Installs NI offline help viewer
+     - Installs LabVIEW core, VI Analyzer support
+     - Installs LabVIEW Command Line Interface (x86)
+     - Removes the temporary feed configuration
+     - Updates feeds again to clean up
+     - Removes the NI Package Manager packages cache to reduce image size
+   - Uses `|| echo "...failed (ignored)"` to log issues but continue if a package fails to install (helpful for optional packages).
+
+7. **Configure VI Server and Cleanup Resources**
+   ```dockerfile
+   RUN move C:\\ni\\resources\\LabVIEW.ini "C:\\Program Files\\National Instruments\\LabVIEW %LV_YEAR%\\LabVIEW.ini" && \
+       move C:\\ni\\resources\\LabVIEWCLI.ini "C:\\Program Files (x86)\\National Instruments\\Shared\\LabVIEW CLI\\LabVIEWCLI.ini" && \
+       rmdir /S /Q "C:\ni\resources"
+   ```
+   - Moves a preconfigured `LabVIEW.ini` into the LabVIEW installation directory to enable VI Server and other required INI tokens.
+   - Moves `LabVIEWCLI.ini` into the LabVIEW CLI installation directory for proper CLI configuration.
+   - Removes the entire temporary resources folder (`C:\ni\resources`) to keep the image smaller and cleaner.
+
+
+
+## How to Build the Image
+
+Once you've reviewed and optionally customized the Dockerfile, you can build your LabVIEW Windows container image using the `docker build` command.
+
+1. Copy `Dockerfile-windows` and the `Resources/Windows Resources` folder to a working directory on your Windows build machine (or use them directly from the repo as your build context).
+2. Ensure the contents of `Resources/Windows Resources` match your environment (for example, the NI Package Manager installer and the appropriate `LabVIEW.ini` file).
+3. From the directory containing `Dockerfile-windows`, run:
 
 ```powershell
-cd .\examples\build-your-own-image
-
-$lvFeed = 'https://download.ni.com/support/nipkg/products/ni-l/' +
-  'ni-labview-2020/20.0/released'
-
-docker build -t labview-custom-windows:2020q1-windows -f Dockerfile-windows `
-  --build-arg LV_FEED_LOCATION=$lvFeed `
-  --build-arg LV_CLI_PORT=3363 `
-  --build-arg INSTALL_OPTIONAL_HELP=0
+docker build -t <image-name> -f Dockerfile-windows .
 ```
 
-If the build succeeds, verify image presence:
+You can override the LabVIEW year and feed location at build time if needed:
+
+```powershell
+docker build -t <image-name> -f Dockerfile-windows `
+  --build-arg LV_YEAR=2026 `
+  --build-arg LV_FEED_LOCATION=<your-offline-feed-url>
+```
+
+After the build completes, verify that the image exists:
 
 ```powershell
 docker images
 ```
 
-## Restart-Aware Path (Recommended for -125071)
-
-Use this path when NIPKG reports reboot-required (`Error -125071`).
-This flow persists checkpoint state in a Docker volume and resumes through a
-phase loop (`phase1..phaseN`) until completion or checkpoint failure.
-
-Script:
-
-- `examples/build-your-own-image/build-windows-lv2020x64-resumable.ps1`
-
-Parameters:
-
-- `-ImageTag` default `labview-custom-windows:2020q1-windows`
-- `-LvFeedLocation` required
-- `-PersistVolumeName` default `vm`
-- `-DnsServer` default `1.1.1.1`
-- `-NipmInstallerDownloadUrl` default
-  `https://download.ni.com/support/nipkg/products/ni-package-manager/installers/NIPackageManager26.0.0.exe`
-- `-NipmInstallerDownloadSha256` default
-  `A2AF381482F85ABA2A963676EAC436F96D69572A9EBFBAF85FF26C372A1995C3`
-- `-NipmInstallerSourcePath` optional host file override
-- `-Phase1Tag` and `-Phase2Tag` optional overrides
-- `-KeepIntermediate` optional switch
-- `-MaxResumePhases` default `4`
-
-Run:
+You can test the image interactively:
 
 ```powershell
-cd .\examples\build-your-own-image
-
-$lvFeed = 'https://download.ni.com/support/nipkg/products/ni-l/' +
-  'ni-labview-2020/20.0/released'
-
-pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
-  -LvFeedLocation $lvFeed `
-  -PersistVolumeName vm
+docker run -it <image-name>
 ```
 
-What the script does:
-
-1. Validates branch is `lv2020x64`.
-1. Verifies Docker is in Windows container mode.
-1. Ensures
-   `examples/build-your-own-image/Resources/Windows Resources/install.exe`
-   exists by using the first valid source:
-   - existing local file
-   - `-NipmInstallerSourcePath` (if supplied)
-   - download from `-NipmInstallerDownloadUrl`
-1. Prints SHA256 for the installer file used.
-1. Ensures the named volume exists (creates it when missing).
-1. Uses `--dns` for phase containers (default `1.1.1.1`).
-1. Builds a seed image with `DEFER_LV_INSTALL=1`.
-1. Runs install in `phase1..phaseN` containers with `-v vm:C:\lv-persist`.
-1. On each `194`, commits a checkpoint image `...-phase<index>` and resumes.
-1. Detects stuck reboot checkpoints when consecutive phases return `194` with
-   unchanged `resume_cursor` and package step.
-1. Stops at success (`0`) or when `-MaxResumePhases` is exceeded.
-1. Writes build summary JSON to `builds/status/lv2020x64-build-summary-*.json`.
-1. Enforces `LV_CLI_PORT=3363`; other values fail fast.
-
-## Confirm Baseline with Built-In MassCompile (No Clone)
-
-Use this check to verify image baseline behavior without mounting external repos.
-
-```powershell
-docker run --rm labview-custom-windows:2020q1-windows `
-  powershell -NoProfile -Command `
-  "LabVIEWCLI -LabVIEWPath 'C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe' -OperationName MassCompile -DirectoryToCompile 'C:\Program Files\National Instruments\LabVIEW 2020\examples\Arrays' -PortNumber 3363 -Headless"
-```
-
-Expected result:
-
-- Command exits `0`.
-- No `-350000` in output.
-
-Checkpoint artifacts written to the volume:
-
-- `C:\lv-persist\state.json`
-- `C:\lv-persist\install.log`
-
-## Troubleshooting Reboot-Required Installs
-
-### Error `-125071` During Install
-
-If you see:
-
-- `Error -125071: A system reboot is needed to complete the transaction.`
-
-Actions:
-
-1. Use the resumable script instead of Dockerfile-only build.
-1. Keep `-PersistVolumeName vm` so state survives phase transitions.
-1. Inspect checkpoint state:
-
-```powershell
-docker run --rm -v vm:C:\lv-persist mcr.microsoft.com/windows/server:ltsc2022 `
-  powershell -NoProfile -Command "Get-Content C:\lv-persist\state.json"
-```
-
-1. If phase 2 still exits `194`, rerun with `-KeepIntermediate` and inspect
-   `builds/status/lv2020x64-build-summary-*.json` for checkpoint cursor and
-   outcome classification before retrying.
-
-### Missing Feed Location
-
-If build fails with missing feed location:
-
-- Pass `--build-arg LV_FEED_LOCATION=<feed-url>` for Dockerfile-only.
-- Pass `-LvFeedLocation <feed-url>` for the resumable script.
-- Recommended value for this 2020 scope:
-  `https://download.ni.com/support/nipkg/products/ni-l/ni-labview-2020/20.0/released`
-- Do not use local raw metadata folders such as
-  `C:\ProgramData\National Instruments\NI Package Manager\raw\...` as a direct
-  `feed-add` source; they are not valid feed URIs for this workflow.
-
-### Missing Installer Bootstrapper
-
-If build fails before seed image creation due to a missing installer bootstrapper:
-
-1. Rerun with explicit download URL/SHA overrides when needed:
-
-```powershell
-$nipmUrl = 'https://download.ni.com/support/nipkg/products/' +
-  'ni-package-manager/' +
-  'installers/NIPackageManager26.0.0.exe'
-$nipmSha256 = 'A2AF381482F85ABA2A963676EAC436F96D69572A9EBFBAF85FF26C372A1995C3'
-
-pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
-  -LvFeedLocation $lvFeed `
-  -NipmInstallerDownloadUrl $nipmUrl `
-  -NipmInstallerDownloadSha256 $nipmSha256 `
-  -PersistVolumeName vm
-```
-
-1. If download is unavailable, pass a host file directly:
-
-```powershell
-pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
-  -LvFeedLocation $lvFeed `
-  -NipmInstallerSourcePath "D:\Installers\NIPM\install.exe" `
-  -PersistVolumeName vm
-```
-
-1. If the container cannot resolve `download.ni.com`, set a reachable DNS server:
-
-```powershell
-pwsh -NoProfile -File .\build-windows-lv2020x64-resumable.ps1 `
-  -LvFeedLocation $lvFeed `
-  -DnsServer 1.1.1.1 `
-  -PersistVolumeName vm
-```
-
-### Port Contract Mismatch
-
-If CLI cannot connect:
-
-1. Confirm build arg `LV_CLI_PORT`.
-1. Verify final in-image files:
-   - `C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.ini`
-   - `C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini`
-
-
-## Phase 3 Local PPL From Known Image
-
-Use this path to build `lv_icon.lvlibp` from an already-built x64 image.
-
-Script:
-
-- `examples/build-your-own-image/build-lv-icon-ppl-from-image.ps1`
-
-Inputs:
-
-- `-ImageTag` default `labview-custom-windows:2020q1-windows-phase2`
-- `-IconEditorRepoRoot` optional; auto-resolves sibling icon-editor repo
-- `-LvYear` default `2020`
-- `-LvCliPort` default `3363`
-- `-BuildSpecName` default `Editor Packed Library`
-- `-OutputRelativePath` default `resource/plugins/lv_icon.lvlibp`
-- `-KeepContainer` optional switch
-- `-LogRoot` optional override for log output root
-
-Happy path:
-
-```powershell
-cd .\examples\build-your-own-image
-
-pwsh -NoProfile -File .\build-lv-icon-ppl-from-image.ps1 `
-  -ImageTag labview-custom-windows:2020q1-windows-phase2
-```
-
-Debug path (keep failed container):
-
-```powershell
-pwsh -NoProfile -File .\build-lv-icon-ppl-from-image.ps1 `
-  -ImageTag labview-custom-windows:2020q1-windows-phase2 `
-  -KeepContainer
-```
-
-Expected outputs:
-
-- PPL artifact: `<icon-editor-root>\resource\plugins\lv_icon.lvlibp`
-- Logs: `TestResults\agent-logs\ppl-phase3-<timestamp>\`
-- Summary: `summary.json` inside the run log folder
-
-## Troubleshooting Phase 3 PPL Builds
-
-### `-350000` LabVIEWCLI Connection Failure
-
-If you see CLI connection failures:
-
-1. Open run summary/logs under `TestResults\agent-logs\ppl-phase3-<timestamp>\`.
-1. Check `phase3-diag\port-listening.txt` and `phase3-diag\netstat-ano.txt`.
-1. Verify copied INI files under `phase3-diag\LabVIEW.ini` and `phase3-diag\LabVIEWCLI.ini`.
-1. Re-run with `-KeepContainer` to preserve state for manual inspection.
-
-### Missing Artifact With Zero-Like CLI Output
-
-If `ExecuteBuildSpec` appears to run but output is missing:
-
-1. Confirm `BuildSpecName` matches the project build spec.
-1. Confirm `OutputRelativePath` matches expected output location.
-1. Review `executebuildspec.log` and `collect-diagnostics.log` in the same run folder.
-
-## Split-Track Execution (2026 Throughput + 2020 Stabilization)
-
-Use this fork's split-track policy:
-
-- Throughput track: run Phase 3 artifact production against
-  `nationalinstruments/labview:2026q1-windows`.
-- Stabilization track: isolate LabVIEW 2020 diagnostics in a separate manual workflow.
-- Do not retag/publish `labview-custom-windows:2020q1-windows` in this pass.
-
-Local 2026 throughput wrapper:
-
-- `examples/build-your-own-image/run-phase3-throughput-2026.ps1`
-
-Wrapper contract:
-
-- `-IconEditorRepoRoot`
-- `-OutputRelativePath`
-- `-LvCliPort` (must be `3363`)
-- `-KeepContainer`
-- `-LogRoot`
-
-Run two consecutive executions (required for local repeatability):
-
-```powershell
-cd .\examples\build-your-own-image
-
-$iconRepo = 'D:\workspace\labview-icon-editor\labview-icon-editor'
-
-pwsh -NoProfile -File .\run-phase3-throughput-2026.ps1 `
-  -IconEditorRepoRoot $iconRepo
-
-pwsh -NoProfile -File .\run-phase3-throughput-2026.ps1 `
-  -IconEditorRepoRoot $iconRepo
-```
-
-Success criteria:
-
-- both runs exit `0`
-- both runs produce non-empty `resource\plugins\lv_icon.lvlibp`
-- each run writes a `summary.json` under
-  `TestResults\agent-logs\phase3-throughput-2026-<timestamp>\ppl-phase3-<timestamp>\`
-
-Conservative cleanup after runs:
-
-```powershell
-pwsh -NoProfile -File .\cleanup-windows-docker-artifacts.ps1 `
-  -Mode Conservative -Apply
-```
-
-Manual 2020 stabilization workflow:
-
-- `.github/workflows/labview-2020-stabilization-matrix.yml`
-
-Workflow inputs:
-
-- `image_tag`
-- `lv_year`
-- `lv_cli_port`
-- `runner_target`
-- `base_matrix`
-- `isolation_mode`
-- `max_cli_attempts`
-
-Stabilization outcomes:
-
-- `pass`
-- `port_not_listening`
-- `cli_connect_fail`
-- `environment_incompatible`
-
-Each run uploads a diagnostic artifact bundle containing `summary.json`,
-MassCompile logs, `lvtemporary_*`, netstat/process snapshots, and INI copies.
-
-## Dedicated Validation Host Policy
-
-For dedicated self-hosted Windows validation machines, use the host policy and
-enforcement runbook in:
-
-- `docs/labview-container-parity.md`
-
-Key rule: do not infer target year from the `LabVIEWCLI` binary version.
-Always pass explicit `LabVIEWPath` and `PortNumber` for operations.
-
-## Image Contract Certification
-
-Use this dedicated certification surface to produce machine-readable image
-contract evidence:
-
-- Profiles: `Tooling/image-contract-profiles.json`
-- Summary schema: `Tooling/image-cert-summary.schema.json`
-- Script: `examples/build-your-own-image/certify-image-contract.ps1`
-- Workflow: `.github/workflows/labview-image-contract-certification.yml`
-
-Certification runs aggregate repeated verifier passes and emit:
-
-- `builds/status/image-contract-cert-summary-*.json`
-- per-run diagnostics in `TestResults/agent-logs/certification-*`
-
-Manual workflow inputs:
-
-- `contract_profile`
-- `image_tag`
-- `runner_target`
-- `isolation_mode`
-- `max_cli_attempts`
-- `repeat_runs`
-
-For `2020-x64-stabilization`, certification may run on hosted lanes for
-diagnostics, but `promotion_eligible` remains `false` unless runner
-fingerprint indicates a real Server 2019 lane.
-
-Comparison procedure (triage discipline):
-
-1. Open previous failing references (`22262096511`, `22262277660`, `22262448572`).
-1. Compare classification and verifier metrics against latest
-   `image-contract-cert-summary-*.json`.
-1. Confirm whether failure is `port_not_listening`, `cli_connect_fail`, or
-   `environment_incompatible` before changing install/runtime settings.
-
-## 2020 Promotion Freeze and Gate (Deferred)
-
-Promotion remains blocked for `labview-custom-windows:2020q1-windows` until
-one real Server 2019 lane passes two fresh runs with all of:
-
-- `final_exit_code=0`
-- `contains_minus_350000=false`
-- `port_listening_before_cli=true`
-- `promotion_eligible=true` in certification summary
-
-Only after that gate:
-
-1. create a backup tag for the current canonical image
-1. retag validated candidate to `labview-custom-windows:2020q1-windows`
-
-If any gate fails, keep candidate tags only and continue stabilization without
-retagging canonical.
-
-## Engineered Prompt Template (lv2020x64)
-
-Use this prompt to ask an AI assistant for reproducible updates:
-
-```text
-You are editing a fork at path `labview-for-containers-fork`
-on branch `lv2020x64`.
-
-Goal:
-- Produce a deterministic local Windows image for LabVIEW 2020 x64 + LabVIEWCLI.
-- Optimize for iterative local development speed.
-- Support resumable install when NIPKG reports reboot-required (`Error -125071`).
-
-Hard requirements:
-1) Keep these defaults:
-   - LV_YEAR=2020
-   - LV_CORE_PACKAGE=ni-labview-2020-core-en
-   - LV_CLI_PACKAGE=ni-labview-command-line-interface-x86
-   - LV_CLI_PORT=3363
-   - INSTALL_OPTIONAL_HELP=0
-2) Treat LV_FEED_LOCATION as required for non-deferred install paths.
-3) Mandatory packages must fail hard if package IDs are invalid.
-4) Update both LabVIEW.ini and LabVIEWCLI.ini port settings from LV_CLI_PORT.
-5) Keep a resumable flow that uses Docker volume `vm` (overridable)
-   and exits 194 for reboot checkpoints.
-6) Preserve and extend existing unstaged edits; do not discard them.
-
-Expected outputs:
-- Updated Dockerfile-windows.
-- Updated/reusable resumable host script.
-- Updated in-container installer script.
-- Updated docs with fast path + restart-aware path + troubleshooting.
-- Validation commands to syntax-check PowerShell and verify doc commands.
-```
+From inside the container, you can invoke `LabVIEWCLI` to run VIs, perform builds, or execute VI Analyzer operations. Remember to use the `-Headless` flag for supported LabVIEW versions, as described in the Windows prebuilt documentation.
 
 ## Final Notes
 
-1. Windows container images run only on Windows hosts in Windows mode.
-1. All LabVIEW operations in these containers should use `LabVIEWCLI`.
-1. `examples/integration-into-cicd/runlabview.ps1` now defaults to `2020`.
-1. If you change package IDs or args, retag resulting images for traceability.
-1. For additional headless guidance, see:
-   - [Windows Prebuilt Images](./windows-prebuilt.md)
-   - [Headless LabVIEW](./headless-labview.md)
+Before you finish, keep the following important points in mind:
+
+1. These images are Windows Server–based and can only run on a **Windows host** configured for Windows containers.
+2. Ensure that all required NI packages (LabVIEW core, VI Analyzer support, LabVIEWCLI, CEIP as desired) are installed via `nipkg` for your selected LabVIEW version.
+3. Do not remove the steps that configure VI Server or the `LabVIEW.ini` file; doing so will break LabVIEWCLI operations.
+4. If you modify the Dockerfile or build context, rebuild the image using a new tag, for example:
+   ```powershell
+   docker build -t labview-custom-windows:2026q1 -f Dockerfile-windows .
+   ```
+5. Start by testing the image interactively to confirm that LabVIEWCLI works end-to-end before integrating it into CI/CD pipelines.
+6. Consider publishing your custom image to a private container registry (such as GHCR or Docker Hub) for easier sharing across your team or CI systems.
+7. For guidance on running LabVIEW headlessly in Windows containers and using the `-Headless` argument, see the [Windows Prebuilt Images](./windows-prebuilt.md) and [Headless LabVIEW](./headless-labview.md) documentation.
+
+## What's next
+
+- Learn how to use the official prebuilt images: [Using the Prebuilt Images](./use-prebuilt-image.md)
+- Review Windows container behavior and requirements: [Windows Prebuilt Images](./windows-prebuilt.md)
+- Explore CI/CD integration patterns and LabVIEWCLI usage: [Examples](./examples.md)
+- Use fork-specific stabilization and promotion runbooks: [Windows Custom Images Operations](./windows-custom-images-operations.md)


### PR DESCRIPTION
## Summary
- stabilize 2026 certification path first by enforcing hosted/self-hosted image preflight and evidence contract checks
- refine certification classification semantics and summary metrics for preflight vs runtime failures
- add `Tooling/Assert-ImageCertificationEvidence.ps1` as a hard gate in certification workflow
- harmonize `docs/windows-custom-images.md` to NI canonical structure
- move fork-specific operational policy/runbooks into `docs/windows-custom-images-operations.md`
- refine `AGENTS.md` with docs harmonization contract and validation checklist

## Scope
- Refs #6
- no 2020 canonical retag/promotion changes

## Validation
- PowerShell parse: `Tooling/Assert-ImageCertificationEvidence.ps1`, `examples/build-your-own-image/certify-image-contract.ps1`
- JSON parse: `Tooling/image-cert-summary.schema.json`, `Tooling/image-contract-profiles.json`
- YAML parse: `.github/workflows/labview-image-contract-certification.yml`
- docs heading parity check vs `upstream/main:docs/windows-custom-images.md`
- internal link checks for modified docs