### PR TITLE
Issue #6: profile-controlled listener gate for 2026 certification

### DIFF
--- a/Tooling/image-cert-summary.schema.json
+++ b/Tooling/image-cert-summary.schema.json
@@ -7,6 +7,7 @@
     "generated_utc",
     "contract_profile",
     "image_tag",
+    "runner_target",
     "runner_fingerprint",
     "verification_metrics",
     "classification",

--- a/Tooling/image-contract-profiles.json
+++ b/Tooling/image-contract-profiles.json
@@ -4,15 +4,20 @@
     "2020-x64-stabilization": {
       "lv_year": "2020",
       "lv_cli_port": "3363",
+      "port_contract_scope": "container-image-contract",
+      "notes": "Intentional split-track override. Host-native contract remains 2020/64=3366 in Tooling/labviewcli-port-contract.json.",
       "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2020\\examples\\Arrays",
       "requires_real_server2019": true,
+      "require_port_listener": true,
       "required_repeat_runs": 2
     },
     "2026-x64-throughput": {
       "lv_year": "2026",
       "lv_cli_port": "3363",
+      "port_contract_scope": "container-image-contract",
       "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2026\\examples\\Arrays",
       "requires_real_server2019": false,
+      "require_port_listener": false,
       "required_repeat_runs": 2
     }
   }


### PR DESCRIPTION
## Summary
Backports the proven org fix to make listener gating profile-controlled for image certification.

### What changed
- `examples/build-your-own-image/certify-image-contract.ps1`
  - add `require_port_listener` profile control (default true)
  - apply listener gate only when required by profile
  - prevent `port_not_listening` classification when listener is not required
  - add explicit pass reason when listener is not enforced
  - harden `GITHUB_OUTPUT` null/empty guard
- `Tooling/image-contract-profiles.json`
  - add `require_port_listener` for both profiles (`2020=true`, `2026=false`)
  - add `port_contract_scope` and note clarifying host-native contract remains separate
- `Tooling/image-cert-summary.schema.json`
  - require `runner_target`

## Validation
- PowerShell parse check passed for `certify-image-contract.ps1`
- JSON parse passed for both Tooling JSON files
- `Tooling/Assert-ImageCertificationEvidence.ps1` successfully validated an existing summary

## Scope Guard
- No workflow topology changes
- No 2020 retag/publish behavior changes

Supersedes #7 and #8 for this deterministic fix.

Refs #6
